### PR TITLE
refactor: integrate rjds/php-dto for attribute-based DTO mapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,12 @@
     "description": "A client that integrates the LastFM API",
     "type": "library",
     "license": "MIT",
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://ruben-jakob-digital-solutions.repo.repman.rubenjakob.com"
+        }
+    ],
     "autoload": {
         "psr-4": {
             "Rjds\\PhpLastfmClient\\": "src/"
@@ -20,7 +26,8 @@
         }
     ],
     "require": {
-        "php": "^8.4"
+        "php": "^8.4",
+        "rjds/php-dto": "^1.0"
     },
     "require-dev": {
         "phpro/grumphp": "^2.19",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,67 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4aca3d228e458bbc9ab409d40e02a48b",
-    "packages": [],
+    "content-hash": "cd1442f0f27df55d2602768818e9e402",
+    "packages": [
+        {
+            "name": "rjds/php-dto",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/RubenJ01/php-dto.git",
+                "reference": "5021412bb5eb7c408aaff1447b67e62a7e40dbfb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/RubenJ01/php-dto/zipball/5021412bb5eb7c408aaff1447b67e62a7e40dbfb",
+                "reference": "5021412bb5eb7c408aaff1447b67e62a7e40dbfb",
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://ruben-jakob-digital-solutions.repo.repman.rubenjakob.com/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
+            },
+            "require": {
+                "php": "^8.4"
+            },
+            "require-dev": {
+                "infection/infection": "*",
+                "phpro/grumphp": "^2.19",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^13.0",
+                "squizlabs/php_codesniffer": "^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Rjds\\PhpDto\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Rjds\\PhpDto\\Tests\\": "tests/"
+                }
+            },
+            "notification-url": "https://ruben-jakob-digital-solutions.repo.repman.rubenjakob.com/downloads",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ruben Eekhof",
+                    "email": "rubeneekhof@gmail.com"
+                }
+            ],
+            "description": "A PHP library to map associative arrays to typed DTOs using attributes.",
+            "support": {
+                "source": "https://github.com/RubenJ01/php-dto/tree/v1.0.0",
+                "issues": "https://github.com/RubenJ01/php-dto/issues"
+            },
+            "time": "2026-03-15T12:27:22+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "amphp/amp",

--- a/src/Dto/ImageDto.php
+++ b/src/Dto/ImageDto.php
@@ -4,22 +4,14 @@ declare(strict_types=1);
 
 namespace Rjds\PhpLastfmClient\Dto;
 
+use Rjds\PhpDto\Attribute\MapFrom;
+
 final readonly class ImageDto
 {
     public function __construct(
         public string $size,
+        #[MapFrom('#text')]
         public string $url,
     ) {
-    }
-
-    /**
-     * @param array{size: string, '#text': string} $data
-     */
-    public static function fromArray(array $data): self
-    {
-        return new self(
-            size: $data['size'],
-            url: $data['#text'],
-        );
     }
 }

--- a/src/Dto/UserDto.php
+++ b/src/Dto/UserDto.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Rjds\PhpLastfmClient\Dto;
 
+use Rjds\PhpDto\Attribute\ArrayOf;
+use Rjds\PhpDto\Attribute\CastTo;
+use Rjds\PhpDto\Attribute\MapFrom;
+
 final readonly class UserDto
 {
     /**
@@ -14,54 +18,30 @@ final readonly class UserDto
         public string $realname,
         public string $url,
         public string $country,
+        #[CastTo('int')]
         public int $age,
+        #[CastTo('bool')]
         public bool $subscriber,
+        #[CastTo('int')]
         public int $playcount,
+        #[MapFrom('artist_count')]
+        #[CastTo('int')]
         public int $artistCount,
+        #[MapFrom('track_count')]
+        #[CastTo('int')]
         public int $trackCount,
+        #[MapFrom('album_count')]
+        #[CastTo('int')]
         public int $albumCount,
+        #[CastTo('int')]
         public int $playlists,
+        #[MapFrom('image')]
+        #[ArrayOf(ImageDto::class)]
         public array $images,
+        #[MapFrom('registered.unixtime')]
+        #[CastTo('datetime')]
         public \DateTimeImmutable $registered,
         public string $type,
     ) {
-    }
-
-    /**
-     * @param array{
-     *     name: string,
-     *     realname: string,
-     *     url: string,
-     *     country: string,
-     *     age: string,
-     *     subscriber: string,
-     *     playcount: string,
-     *     artist_count: string,
-     *     track_count: string,
-     *     album_count: string,
-     *     playlists: string,
-     *     image: list<array{size: string, '#text': string}>,
-     *     registered: array{unixtime: string, '#text': int},
-     *     type: string
-     * } $data
-     */
-    public static function fromArray(array $data): self
-    {
-        return new self(
-            name: $data['name'],
-            realname: $data['realname'],
-            url: $data['url'],
-            country: $data['country'],
-            age: (int) $data['age'],
-            subscriber: $data['subscriber'] === '1',
-            playcount: (int) $data['playcount'],
-            artistCount: (int) $data['artist_count'],
-            trackCount: (int) $data['track_count'],
-            albumCount: (int) $data['album_count'],
-            playlists: (int) $data['playlists'],
-            images: array_map(ImageDto::fromArray(...), $data['image']),
-            registered: (new \DateTimeImmutable())->setTimestamp((int) $data['registered']['unixtime']),
-            type: $data['type'],
-        );
     }
 }

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rjds\PhpLastfmClient\Service;
 
+use Rjds\PhpDto\DtoMapper;
 use Rjds\PhpLastfmClient\Dto\UserDto;
 use Rjds\PhpLastfmClient\LastfmClient;
 
@@ -11,6 +12,7 @@ final readonly class UserService
 {
     public function __construct(
         private LastfmClient $client,
+        private DtoMapper $mapper = new DtoMapper(),
     ) {
     }
 
@@ -23,9 +25,9 @@ final readonly class UserService
     {
         $response = $this->client->call('user.getinfo', ['user' => $user]);
 
-        /** @var array{name: string, realname: string, url: string, country: string, age: string, subscriber: string, playcount: string, artist_count: string, track_count: string, album_count: string, playlists: string, image: list<array{size: string, '#text': string}>, registered: array{unixtime: string, '#text': int}, type: string} $userData */
+        /** @var array<string, mixed> $userData */
         $userData = $response['user'];
 
-        return UserDto::fromArray($userData);
+        return $this->mapper->map($userData, UserDto::class);
     }
 }

--- a/tests/Dto/ImageDtoTest.php
+++ b/tests/Dto/ImageDtoTest.php
@@ -6,19 +6,20 @@ namespace Rjds\PhpLastfmClient\Tests\Dto;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Rjds\PhpDto\DtoMapper;
 use Rjds\PhpLastfmClient\Dto\ImageDto;
 
 final class ImageDtoTest extends TestCase
 {
     #[Test]
-    public function itCreatesFromArray(): void
+    public function itMapsFromApiData(): void
     {
-        $data = [
+        $mapper = new DtoMapper();
+
+        $dto = $mapper->map([
             'size' => 'large',
             '#text' => 'https://lastfm.freetls.fastly.net/i/u/174s/image.png',
-        ];
-
-        $dto = ImageDto::fromArray($data);
+        ], ImageDto::class);
 
         $this->assertSame('large', $dto->size);
         $this->assertSame('https://lastfm.freetls.fastly.net/i/u/174s/image.png', $dto->url);

--- a/tests/Dto/UserDtoTest.php
+++ b/tests/Dto/UserDtoTest.php
@@ -6,17 +6,23 @@ namespace Rjds\PhpLastfmClient\Tests\Dto;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Rjds\PhpDto\DtoMapper;
 use Rjds\PhpLastfmClient\Dto\ImageDto;
 use Rjds\PhpLastfmClient\Dto\UserDto;
 
 final class UserDtoTest extends TestCase
 {
-    #[Test]
-    public function itCreatesFromApiResponse(): void
-    {
-        $data = self::userApiResponse();
+    private DtoMapper $mapper;
 
-        $dto = UserDto::fromArray($data);
+    protected function setUp(): void
+    {
+        $this->mapper = new DtoMapper();
+    }
+
+    #[Test]
+    public function itMapsFromApiResponse(): void
+    {
+        $dto = $this->mapper->map(self::userApiResponse(), UserDto::class);
 
         $this->assertSame('RJ', $dto->name);
         $this->assertSame('Richard Jones', $dto->realname);
@@ -36,11 +42,10 @@ final class UserDtoTest extends TestCase
     #[Test]
     public function itParsesImages(): void
     {
-        $data = self::userApiResponse();
-
-        $dto = UserDto::fromArray($data);
+        $dto = $this->mapper->map(self::userApiResponse(), UserDto::class);
 
         $this->assertCount(2, $dto->images);
+        $this->assertInstanceOf(ImageDto::class, $dto->images[0]);
         $this->assertSame('small', $dto->images[0]->size);
         $this->assertSame('https://lastfm.freetls.fastly.net/i/u/34s/image.png', $dto->images[0]->url);
         $this->assertSame('large', $dto->images[1]->size);
@@ -53,28 +58,13 @@ final class UserDtoTest extends TestCase
         $data = self::userApiResponse();
         $data['subscriber'] = '0';
 
-        $dto = UserDto::fromArray($data);
+        $dto = $this->mapper->map($data, UserDto::class);
 
         $this->assertFalse($dto->subscriber);
     }
 
     /**
-     * @return array{
-     *     name: string,
-     *     realname: string,
-     *     url: string,
-     *     country: string,
-     *     age: string,
-     *     subscriber: string,
-     *     playcount: string,
-     *     artist_count: string,
-     *     track_count: string,
-     *     album_count: string,
-     *     playlists: string,
-     *     image: list<array{size: string, '#text': string}>,
-     *     registered: array{unixtime: string, '#text': int},
-     *     type: string
-     * }
+     * @return array<string, mixed>
      */
     private static function userApiResponse(): array
     {


### PR DESCRIPTION
## Summary

Replaces manual `fromArray()` methods with attribute-based mapping via `rjds/php-dto`.

### Changes

- Added `rjds/php-dto` as a dependency (served via Repman)
- Added Repman repository to `composer.json`
- **ImageDto**: Removed `fromArray()`, added `#[MapFrom('#text')]` for the `url` property
- **UserDto**: Removed 30-line `fromArray()` method, replaced with attributes:
  - `#[MapFrom]` for snake_case and nested keys
  - `#[CastTo]` for string-to-int/bool/datetime conversions
  - `#[ArrayOf]` for nested image DTOs
- **UserService**: Uses `DtoMapper::map()` instead of `UserDto::fromArray()`
- Updated all DTO tests to use `DtoMapper`

### Quality

- GrumPHP: all green (phpcs, phpstan, phpunit)
- Infection: 100% MSI (28/28 mutants killed)

Closes #4
