### PR TITLE
feat: implement library.getArtists endpoint

### DIFF
--- a/src/Dto/LibraryArtistDto.php
+++ b/src/Dto/LibraryArtistDto.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Dto;
+
+use Rjds\PhpDto\Attribute\ArrayOf;
+use Rjds\PhpDto\Attribute\CastTo;
+use Rjds\PhpDto\Attribute\MapFrom;
+
+final readonly class LibraryArtistDto
+{
+    /**
+     * @param list<ImageDto> $images
+     */
+    public function __construct(
+        public string $name,
+        public string $url,
+        public string $mbid,
+        #[CastTo('int')]
+        public int $tagcount,
+        #[CastTo('int')]
+        public int $playcount,
+        #[CastTo('bool')]
+        public bool $streamable,
+        #[MapFrom('image')]
+        #[ArrayOf(ImageDto::class)]
+        public array $images,
+    ) {
+    }
+}

--- a/src/Dto/PaginatedResponse.php
+++ b/src/Dto/PaginatedResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Dto;
+
+/**
+ * A generic paginated response wrapper.
+ *
+ * @template T
+ */
+final readonly class PaginatedResponse
+{
+    /**
+     * @param list<T> $items
+     */
+    public function __construct(
+        public array $items,
+        public PaginationDto $pagination,
+    ) {
+    }
+}

--- a/src/Dto/PaginationDto.php
+++ b/src/Dto/PaginationDto.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Dto;
+
+use Rjds\PhpDto\Attribute\CastTo;
+
+final readonly class PaginationDto
+{
+    public function __construct(
+        #[CastTo('int')]
+        public int $page,
+        #[CastTo('int')]
+        public int $perPage,
+        #[CastTo('int')]
+        public int $total,
+        #[CastTo('int')]
+        public int $totalPages,
+    ) {
+    }
+}

--- a/src/LastfmClient.php
+++ b/src/LastfmClient.php
@@ -7,6 +7,7 @@ namespace Rjds\PhpLastfmClient;
 use Rjds\PhpLastfmClient\Exception\LastfmApiException;
 use Rjds\PhpLastfmClient\Http\HttpClientInterface;
 use Rjds\PhpLastfmClient\Http\LastfmHttpClient;
+use Rjds\PhpLastfmClient\Service\LibraryService;
 use Rjds\PhpLastfmClient\Service\UserService;
 
 final class LastfmClient
@@ -25,6 +26,14 @@ final class LastfmClient
     public function user(): UserService
     {
         return new UserService($this);
+    }
+
+    /**
+     * Access library-related API methods.
+     */
+    public function library(): LibraryService
+    {
+        return new LibraryService($this);
     }
 
     /**

--- a/src/Service/LibraryService.php
+++ b/src/Service/LibraryService.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Service;
+
+use Rjds\PhpDto\DtoMapper;
+use Rjds\PhpLastfmClient\Dto\LibraryArtistDto;
+use Rjds\PhpLastfmClient\Dto\PaginatedResponse;
+use Rjds\PhpLastfmClient\Dto\PaginationDto;
+use Rjds\PhpLastfmClient\LastfmClient;
+
+final readonly class LibraryService
+{
+    public function __construct(
+        private LastfmClient $client,
+        private DtoMapper $mapper = new DtoMapper(),
+    ) {
+    }
+
+    /**
+     * Get a paginated list of all the artists in a user's library.
+     *
+     * @see https://lastfm-docs.github.io/api-docs/library/getArtists/
+     *
+     * @return PaginatedResponse<LibraryArtistDto>
+     */
+    public function getArtists(string $user, int $limit = 50, int $page = 1): PaginatedResponse
+    {
+        $response = $this->client->call('library.getartists', [
+            'user' => $user,
+            'limit' => (string) $limit,
+            'page' => (string) $page,
+        ]);
+
+        /** @var array<string, mixed> $data */
+        $data = $response['artists'];
+
+        /** @var list<array<string, mixed>> $artistList */
+        $artistList = $data['artist'];
+
+        /** @var list<LibraryArtistDto> $artists */
+        $artists = [];
+        foreach ($artistList as $item) {
+            $artists[] = $this->mapper->map($item, LibraryArtistDto::class);
+        }
+
+        /** @var array<string, mixed> $attrData */
+        $attrData = $data['@attr'];
+        $pagination = $this->mapper->map($attrData, PaginationDto::class);
+
+        return new PaginatedResponse($artists, $pagination);
+    }
+}

--- a/tests/Dto/LibraryArtistDtoTest.php
+++ b/tests/Dto/LibraryArtistDtoTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Tests\Dto;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Rjds\PhpDto\DtoMapper;
+use Rjds\PhpLastfmClient\Dto\ImageDto;
+use Rjds\PhpLastfmClient\Dto\LibraryArtistDto;
+
+final class LibraryArtistDtoTest extends TestCase
+{
+    private DtoMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new DtoMapper();
+    }
+
+    #[Test]
+    public function itMapsFromApiResponse(): void
+    {
+        $dto = $this->mapper->map(self::artistApiData(), LibraryArtistDto::class);
+
+        $this->assertSame('Queen', $dto->name);
+        $this->assertSame('https://www.last.fm/music/Queen', $dto->url);
+        $this->assertSame('5eecaf18-02ec-47af-a4f2-7831db373419', $dto->mbid);
+        $this->assertSame(0, $dto->tagcount);
+        $this->assertSame(1511, $dto->playcount);
+        $this->assertFalse($dto->streamable);
+    }
+
+    #[Test]
+    public function itParsesImages(): void
+    {
+        $dto = $this->mapper->map(self::artistApiData(), LibraryArtistDto::class);
+
+        $this->assertCount(2, $dto->images);
+        $this->assertInstanceOf(ImageDto::class, $dto->images[0]);
+        $this->assertSame('small', $dto->images[0]->size);
+        $this->assertSame(
+            'https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png',
+            $dto->images[0]->url,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function artistApiData(): array
+    {
+        return [
+            'name' => 'Queen',
+            'url' => 'https://www.last.fm/music/Queen',
+            'mbid' => '5eecaf18-02ec-47af-a4f2-7831db373419',
+            'tagcount' => '0',
+            'playcount' => '1511',
+            'streamable' => '0',
+            'image' => [
+                [
+                    'size' => 'small',
+                    '#text' => 'https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png',
+                ],
+                [
+                    'size' => 'large',
+                    '#text' => 'https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png',
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Dto/PaginatedResponseTest.php
+++ b/tests/Dto/PaginatedResponseTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Tests\Dto;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Rjds\PhpLastfmClient\Dto\PaginatedResponse;
+use Rjds\PhpLastfmClient\Dto\PaginationDto;
+
+final class PaginatedResponseTest extends TestCase
+{
+    #[Test]
+    public function itHoldsItemsAndPagination(): void
+    {
+        $pagination = new PaginationDto(1, 50, 100, 2);
+        $items = ['item1', 'item2'];
+
+        $response = new PaginatedResponse($items, $pagination);
+
+        $this->assertSame($items, $response->items);
+        $this->assertSame(1, $response->pagination->page);
+        $this->assertSame(50, $response->pagination->perPage);
+        $this->assertSame(100, $response->pagination->total);
+        $this->assertSame(2, $response->pagination->totalPages);
+    }
+}

--- a/tests/Dto/PaginationDtoTest.php
+++ b/tests/Dto/PaginationDtoTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Tests\Dto;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Rjds\PhpDto\DtoMapper;
+use Rjds\PhpLastfmClient\Dto\PaginationDto;
+
+final class PaginationDtoTest extends TestCase
+{
+    #[Test]
+    public function itMapsFromAttrData(): void
+    {
+        $mapper = new DtoMapper();
+
+        $dto = $mapper->map([
+            'page' => '3',
+            'perPage' => '50',
+            'total' => '1931',
+            'totalPages' => '39',
+            'user' => 'rj',
+        ], PaginationDto::class);
+
+        $this->assertSame(3, $dto->page);
+        $this->assertSame(50, $dto->perPage);
+        $this->assertSame(1931, $dto->total);
+        $this->assertSame(39, $dto->totalPages);
+    }
+}

--- a/tests/LastfmClientTest.php
+++ b/tests/LastfmClientTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Rjds\PhpLastfmClient\Exception\LastfmApiException;
 use Rjds\PhpLastfmClient\Http\HttpClientInterface;
 use Rjds\PhpLastfmClient\LastfmClient;
+use Rjds\PhpLastfmClient\Service\LibraryService;
 use Rjds\PhpLastfmClient\Service\UserService;
 
 final class LastfmClientTest extends TestCase
@@ -19,6 +20,14 @@ final class LastfmClientTest extends TestCase
         $client = new LastfmClient('test-api-key');
 
         $this->assertInstanceOf(UserService::class, $client->user());
+    }
+
+    #[Test]
+    public function itReturnsLibraryService(): void
+    {
+        $client = new LastfmClient('test-api-key');
+
+        $this->assertInstanceOf(LibraryService::class, $client->library());
     }
 
     #[Test]

--- a/tests/Service/LibraryServiceTest.php
+++ b/tests/Service/LibraryServiceTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Tests\Service;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Rjds\PhpLastfmClient\Dto\ImageDto;
+use Rjds\PhpLastfmClient\Dto\LibraryArtistDto;
+use Rjds\PhpLastfmClient\Http\HttpClientInterface;
+use Rjds\PhpLastfmClient\LastfmClient;
+
+final class LibraryServiceTest extends TestCase
+{
+    #[Test]
+    public function itReturnsPaginatedArtists(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $httpClient->method('get')
+            ->willReturn((string) json_encode(self::libraryGetArtistsResponse()));
+
+        $client = new LastfmClient('test-api-key', $httpClient);
+        $result = $client->library()->getArtists('rj');
+
+        $this->assertCount(2, $result->items);
+        $this->assertInstanceOf(LibraryArtistDto::class, $result->items[0]);
+        $this->assertSame('Queen', $result->items[0]->name);
+        $this->assertSame(1511, $result->items[0]->playcount);
+        $this->assertSame('Videoclub', $result->items[1]->name);
+        $this->assertSame(1123, $result->items[1]->playcount);
+    }
+
+    #[Test]
+    public function itReturnsPaginationMetadata(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $httpClient->method('get')
+            ->willReturn((string) json_encode(self::libraryGetArtistsResponse()));
+
+        $client = new LastfmClient('test-api-key', $httpClient);
+        $result = $client->library()->getArtists('rj');
+
+        $this->assertSame(1, $result->pagination->page);
+        $this->assertSame(2, $result->pagination->perPage);
+        $this->assertSame(1931, $result->pagination->total);
+        $this->assertSame(966, $result->pagination->totalPages);
+    }
+
+    #[Test]
+    public function itCallsApiWithCorrectParameters(): void
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('get')
+            ->with($this->callback(function (string $url): bool {
+                $this->assertIsString(parse_url($url, PHP_URL_QUERY));
+                parse_str((string) parse_url($url, PHP_URL_QUERY), $params);
+                $this->assertSame('library.getartists', $params['method']);
+                $this->assertSame('testuser', $params['user']);
+                $this->assertSame('10', $params['limit']);
+                $this->assertSame('3', $params['page']);
+
+                return true;
+            }))
+            ->willReturn((string) json_encode(self::libraryGetArtistsResponse()));
+
+        $client = new LastfmClient('test-api-key', $httpClient);
+        $client->library()->getArtists('testuser', 10, 3);
+    }
+
+    #[Test]
+    public function itUsesDefaultLimitAndPage(): void
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('get')
+            ->with($this->callback(function (string $url): bool {
+                $query = parse_url($url, PHP_URL_QUERY);
+                $this->assertIsString($query);
+                parse_str((string) $query, $params);
+                $this->assertSame('50', $params['limit']);
+                $this->assertSame('1', $params['page']);
+
+                return true;
+            }))
+            ->willReturn(
+                (string) json_encode(self::libraryGetArtistsResponse())
+            );
+
+        $client = new LastfmClient('test-api-key', $httpClient);
+        $client->library()->getArtists('rj');
+    }
+
+    #[Test]
+    public function itParsesArtistImages(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $httpClient->method('get')
+            ->willReturn((string) json_encode(self::libraryGetArtistsResponse()));
+
+        $client = new LastfmClient('test-api-key', $httpClient);
+        $result = $client->library()->getArtists('rj');
+
+        $this->assertCount(2, $result->items[0]->images);
+        $this->assertInstanceOf(ImageDto::class, $result->items[0]->images[0]);
+        $this->assertSame('small', $result->items[0]->images[0]->size);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function libraryGetArtistsResponse(): array
+    {
+        return [
+            'artists' => [
+                'artist' => [
+                    [
+                        'name' => 'Queen',
+                        'url' => 'https://www.last.fm/music/Queen',
+                        'mbid' => '5eecaf18-02ec-47af-a4f2-7831db373419',
+                        'tagcount' => '0',
+                        'playcount' => '1511',
+                        'streamable' => '0',
+                        'image' => self::imageData(),
+                    ],
+                    [
+                        'name' => 'Videoclub',
+                        'url' => 'https://www.last.fm/music/Videoclub',
+                        'mbid' => 'f4903035-e9cd-4b7f-b462-0447b0cd490a',
+                        'tagcount' => '0',
+                        'playcount' => '1123',
+                        'streamable' => '0',
+                        'image' => self::imageData(),
+                    ],
+                ],
+                '@attr' => [
+                    'page' => '1',
+                    'total' => '1931',
+                    'user' => 'rj',
+                    'perPage' => '2',
+                    'totalPages' => '966',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array{size: string, '#text': string}>
+     */
+    private static function imageData(): array
+    {
+        return [
+            [
+                'size' => 'small',
+                '#text' => 'https://lastfm.freetls.fastly.net/i/u/34s/img.png',
+            ],
+            [
+                'size' => 'large',
+                '#text' => 'https://lastfm.freetls.fastly.net/i/u/174s/img.png',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Closes #6

## Summary

Implements the `library.getArtists` endpoint which returns a paginated list of all artists in a user's library with play counts and tag counts.

## Changes

### Reusable Pagination Support
- **`PaginationDto`** — maps the `@attr` pagination metadata (page, perPage, total, totalPages) from Last.fm API responses
- **`PaginatedResponse<T>`** — generic wrapper holding items + pagination, reusable for all paginated endpoints

### Library Endpoint
- **`LibraryArtistDto`** — maps artist data (name, url, mbid, tagcount, playcount, streamable, images) using php-dto attributes
- **`LibraryService`** — service with `getArtists(user, limit, page)` method
- Wired into `LastfmClient` via `$client->library()->getArtists()`

### Tests
- `PaginationDtoTest` — verifies string-to-int casting from API response
- `PaginatedResponseTest` — verifies wrapper holds items and pagination
- `LibraryArtistDtoTest` — verifies DTO mapping including images
- `LibraryServiceTest` — verifies API call parameters, pagination, artist parsing, and default values
- `LastfmClientTest` — added `itReturnsLibraryService` test

### Usage

```php
$client = new LastfmClient('your-api-key');
$result = $client->library()->getArtists('rj', limit: 10, page: 1);

foreach ($result->items as $artist) {
    echo "{$artist->name}: {$artist->playcount} plays\n";
}

echo "Page {$result->pagination->page} of {$result->pagination->totalPages}";
```
