### PR TITLE
docs: add README overview and per-endpoint documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Php Lastfm Client
+# PHP Last.fm Client
 
-A client that integrates the LastFM API
+A PHP client library for the [Last.fm API](https://www.last.fm/api).
 
 ## Requirements
 
@@ -12,7 +12,7 @@ A client that integrates the LastFM API
 composer require rjds/php-lastfm-client
 ```
 
-## Usage
+## Quick Start
 
 ```php
 use Rjds\PhpLastfmClient\LastfmClient;
@@ -21,12 +21,56 @@ $client = new LastfmClient('your-api-key');
 
 // Get user info
 $user = $client->user()->getInfo('rj');
+echo $user->name;       // "RJ"
+echo $user->playcount;  // 150316
 
-echo $user->name;        // "RJ"
-echo $user->playcount;   // 150316
-echo $user->country;     // "United Kingdom"
-echo $user->subscriber;  // true
-echo $user->registered->format('Y-m-d'); // "2002-11-20"
+// Get library artists (paginated)
+$result = $client->library()->getArtists('rj', limit: 10);
+foreach ($result->items as $artist) {
+    echo "{$artist->name}: {$artist->playcount} plays\n";
+}
+echo "Page {$result->pagination->page} of {$result->pagination->totalPages}";
+```
+
+## Available Endpoints
+
+| Service   | Method         | Description                              | Docs                                     |
+|-----------|----------------|------------------------------------------|------------------------------------------|
+| `user`    | `getInfo`      | Get information about a user profile     | [View](docs/user/getInfo.md)             |
+| `library` | `getArtists`   | Get all artists in a user's library      | [View](docs/library/getArtists.md)       |
+
+## Error Handling
+
+The client throws `LastfmApiException` for API errors, which includes the Last.fm [error code](https://lastfm-docs.github.io/api-docs/#error-codes):
+
+```php
+use Rjds\PhpLastfmClient\Exception\LastfmApiException;
+
+try {
+    $user = $client->user()->getInfo('nonexistent-user');
+} catch (LastfmApiException $e) {
+    echo $e->getMessage();       // "User not found"
+    echo $e->getApiErrorCode();  // 6
+}
+```
+
+## Custom HTTP Client
+
+By default, the client uses `file_get_contents`. You can provide your own HTTP client by implementing `HttpClientInterface`:
+
+```php
+use Rjds\PhpLastfmClient\Http\HttpClientInterface;
+use Rjds\PhpLastfmClient\LastfmClient;
+
+class GuzzleHttpClient implements HttpClientInterface
+{
+    public function get(string $url): string
+    {
+        // Your Guzzle implementation
+    }
+}
+
+$client = new LastfmClient('your-api-key', new GuzzleHttpClient());
 ```
 
 ## Compatibility

--- a/docs/library/getArtists.md
+++ b/docs/library/getArtists.md
@@ -1,0 +1,113 @@
+# library.getArtists
+
+Get a paginated list of all the artists in a user's library, with play counts and tag counts.
+
+**Last.fm API Reference:** [library.getArtists](https://lastfm-docs.github.io/api-docs/library/getArtists/)
+
+## Usage
+
+```php
+use Rjds\PhpLastfmClient\LastfmClient;
+
+$client = new LastfmClient('your-api-key');
+
+$result = $client->library()->getArtists('rj');
+```
+
+## Parameters
+
+| Parameter | Type     | Required | Default | Description                              |
+|-----------|----------|----------|---------|------------------------------------------|
+| `$user`   | `string` | Yes      | —       | The user whose library to fetch.         |
+| `$limit`  | `int`    | No       | `50`    | Number of results per page (max 2000).   |
+| `$page`   | `int`    | No       | `1`     | The page number to fetch.                |
+
+## Return Type
+
+Returns a `PaginatedResponse<LibraryArtistDto>` object.
+
+### PaginatedResponse Properties
+
+| Property     | Type                     | Description                    |
+|--------------|--------------------------|--------------------------------|
+| `items`      | `list<LibraryArtistDto>` | The artists on this page.      |
+| `pagination` | `PaginationDto`          | Pagination metadata.           |
+
+### PaginationDto Properties
+
+| Property     | Type  | Description                      |
+|--------------|-------|----------------------------------|
+| `page`       | `int` | The current page number.         |
+| `perPage`    | `int` | Number of results per page.      |
+| `total`      | `int` | Total number of results.         |
+| `totalPages` | `int` | Total number of pages.           |
+
+### LibraryArtistDto Properties
+
+| Property     | Type             | Description                              |
+|--------------|------------------|------------------------------------------|
+| `name`       | `string`         | The artist's name.                       |
+| `url`        | `string`         | URL to the artist's Last.fm page.        |
+| `mbid`       | `string`         | MusicBrainz ID.                          |
+| `tagcount`   | `int`            | Number of tags the user has applied.     |
+| `playcount`  | `int`            | Number of times the user played this artist. |
+| `streamable` | `bool`           | Whether the artist is streamable.        |
+| `images`     | `list<ImageDto>` | Artist images in various sizes.          |
+
+### ImageDto Properties
+
+| Property | Type     | Description                                         |
+|----------|----------|-----------------------------------------------------|
+| `size`   | `string` | Image size (`"small"`, `"medium"`, `"large"`, etc). |
+| `url`    | `string` | URL to the image.                                   |
+
+## Examples
+
+### Basic Usage
+
+```php
+$result = $client->library()->getArtists('rj');
+
+foreach ($result->items as $artist) {
+    echo "{$artist->name}: {$artist->playcount} plays\n";
+}
+```
+
+### Pagination
+
+```php
+// Fetch page 3, 10 artists per page
+$result = $client->library()->getArtists('rj', limit: 10, page: 3);
+
+echo "Page {$result->pagination->page} of {$result->pagination->totalPages}\n";
+echo "Total artists: {$result->pagination->total}\n";
+```
+
+### Iterating All Pages
+
+```php
+$page = 1;
+
+do {
+    $result = $client->library()->getArtists('rj', limit: 100, page: $page);
+
+    foreach ($result->items as $artist) {
+        echo "{$artist->name}: {$artist->playcount} plays\n";
+    }
+
+    $page++;
+} while ($page <= $result->pagination->totalPages);
+```
+
+### Accessing Artist Images
+
+```php
+$result = $client->library()->getArtists('rj', limit: 5);
+
+foreach ($result->items as $artist) {
+    echo "{$artist->name}\n";
+    foreach ($artist->images as $image) {
+        echo "  {$image->size}: {$image->url}\n";
+    }
+}
+```

--- a/docs/user/getInfo.md
+++ b/docs/user/getInfo.md
@@ -1,0 +1,69 @@
+# user.getInfo
+
+Get information about a user's profile.
+
+**Last.fm API Reference:** [user.getInfo](https://lastfm-docs.github.io/api-docs/user/getInfo/)
+
+## Usage
+
+```php
+use Rjds\PhpLastfmClient\LastfmClient;
+
+$client = new LastfmClient('your-api-key');
+
+$user = $client->user()->getInfo('rj');
+```
+
+## Parameters
+
+| Parameter | Type     | Required | Description                        |
+|-----------|----------|----------|------------------------------------|
+| `$user`   | `string` | Yes      | The username to fetch info for.    |
+
+## Return Type
+
+Returns a `UserDto` object.
+
+### UserDto Properties
+
+| Property       | Type                | Description                                  |
+|----------------|---------------------|----------------------------------------------|
+| `name`         | `string`            | The user's Last.fm username.                 |
+| `realname`     | `string`            | The user's real name.                        |
+| `url`          | `string`            | URL to the user's Last.fm profile.           |
+| `country`      | `string`            | The user's country.                          |
+| `age`          | `int`               | The user's age.                              |
+| `subscriber`   | `bool`              | Whether the user is a subscriber.            |
+| `playcount`    | `int`               | Total number of scrobbles.                   |
+| `artistCount`  | `int`               | Number of unique artists scrobbled.          |
+| `trackCount`   | `int`               | Number of unique tracks scrobbled.           |
+| `albumCount`   | `int`               | Number of unique albums scrobbled.           |
+| `playlists`    | `int`               | Number of playlists.                         |
+| `images`       | `list<ImageDto>`    | Profile images in various sizes.             |
+| `registered`   | `DateTimeImmutable`  | When the user registered.                    |
+| `type`         | `string`            | The user's type (e.g. `"alum"`, `"user"`).   |
+
+### ImageDto Properties
+
+| Property | Type     | Description                                         |
+|----------|----------|-----------------------------------------------------|
+| `size`   | `string` | Image size (`"small"`, `"medium"`, `"large"`, etc). |
+| `url`    | `string` | URL to the image.                                   |
+
+## Example
+
+```php
+$user = $client->user()->getInfo('rj');
+
+echo $user->name;                          // "RJ"
+echo $user->realname;                      // "Richard Jones"
+echo $user->playcount;                     // 150316
+echo $user->country;                       // "United Kingdom"
+echo $user->subscriber;                    // true
+echo $user->registered->format('Y-m-d');   // "2002-11-20"
+
+// Access profile images
+foreach ($user->images as $image) {
+    echo "{$image->size}: {$image->url}\n";
+}
+```


### PR DESCRIPTION
Closes #8

## Summary

Adds comprehensive documentation with a high-level README overview and detailed per-endpoint docs.

## Changes

### README.md
- Quick start with examples for both `user.getInfo` and `library.getArtists`
- Endpoint table linking to detailed docs
- Error handling section with `LastfmApiException` usage
- Custom HTTP client section showing how to implement `HttpClientInterface`

### docs/user/getInfo.md
- Full parameter table
- Complete `UserDto` and `ImageDto` property reference
- Usage examples

### docs/library/getArtists.md
- Full parameter table with defaults
- Complete `PaginatedResponse`, `PaginationDto`, `LibraryArtistDto`, and `ImageDto` property reference
- Examples for basic usage, pagination, iterating all pages, and accessing images
