### PR TITLE
feat: implement track.scrobble endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ echo "Page {$result->pagination->page} of {$result->pagination->totalPages}";
 |-----------|----------------|------------------------------------------|------------------------------------------|
 | `user`    | `getInfo`      | Get information about a user profile     | [View](docs/user/getInfo.md)             |
 | `library` | `getArtists`   | Get all artists in a user's library      | [View](docs/library/getArtists.md)       |
+| `track`   | `scrobble`     | Scrobble a track to a user's profile     | [View](docs/track/scrobble.md)           |
 
 ## Error Handling
 

--- a/docs/track/scrobble.md
+++ b/docs/track/scrobble.md
@@ -1,0 +1,153 @@
+# track.scrobble
+
+Scrobble a track, or a batch of tracks (up to 50), to a user's profile. This is an authenticated write endpoint.
+
+**Last.fm API Reference:** [track.scrobble](https://www.last.fm/api/show/track.scrobble)
+
+## Authentication
+
+This endpoint requires authentication. You must provide an `apiSecret` and `sessionKey` when creating the client:
+
+```php
+use Rjds\PhpLastfmClient\LastfmClient;
+
+$client = new LastfmClient(
+    apiKey: 'your-api-key',
+    apiSecret: 'your-api-secret',
+    sessionKey: 'user-session-key',
+);
+```
+
+The client automatically generates the required API signature for each authenticated request.
+
+## Usage
+
+### Single Scrobble
+
+```php
+use Rjds\PhpLastfmClient\Dto\Scrobble;
+
+$result = $client->track()->scrobble(new Scrobble(
+    artist: 'Radiohead',
+    track: 'Karma Police',
+    timestamp: time(),
+));
+
+echo "Accepted: {$result->accepted}, Ignored: {$result->ignored}\n";
+```
+
+### Batch Scrobble
+
+```php
+$result = $client->track()->scrobbleBatch([
+    new Scrobble(
+        artist: 'Radiohead',
+        track: 'Karma Police',
+        timestamp: time() - 600,
+        album: 'OK Computer',
+    ),
+    new Scrobble(
+        artist: 'Radiohead',
+        track: 'Lucky',
+        timestamp: time() - 300,
+        album: 'OK Computer',
+    ),
+]);
+
+echo "Accepted: {$result->accepted}, Ignored: {$result->ignored}\n";
+```
+
+## Scrobble Parameters
+
+The `Scrobble` value object accepts the following parameters:
+
+| Parameter      | Type    | Required | Description                                                  |
+|----------------|---------|----------|--------------------------------------------------------------|
+| `$artist`      | `string` | Yes     | The artist name.                                             |
+| `$track`       | `string` | Yes     | The track name.                                              |
+| `$timestamp`   | `int`    | Yes     | UNIX timestamp when the track started playing (UTC).         |
+| `$album`       | `?string`| No      | The album name.                                              |
+| `$albumArtist` | `?string`| No      | The album artist, if different from the track artist.        |
+| `$trackNumber` | `?int`   | No      | The track number on the album.                               |
+| `$mbid`        | `?string`| No      | The MusicBrainz Track ID.                                    |
+| `$duration`    | `?int`   | No      | The track length in seconds.                                 |
+| `$chosenByUser`| `?bool`  | No      | `true` if user chose the song, `false` if auto-selected.    |
+
+## Return Type
+
+Both `scrobble()` and `scrobbleBatch()` return a `ScrobbleResponseDto`.
+
+### ScrobbleResponseDto Properties
+
+| Property    | Type                       | Description                     |
+|-------------|----------------------------|---------------------------------|
+| `accepted`  | `int`                      | Number of accepted scrobbles.   |
+| `ignored`   | `int`                      | Number of ignored scrobbles.    |
+| `scrobbles` | `list<ScrobbleResultDto>`  | Details for each scrobble.      |
+
+### ScrobbleResultDto Properties
+
+| Property               | Type     | Description                                        |
+|------------------------|----------|----------------------------------------------------|
+| `track`                | `string` | The track name (possibly corrected).               |
+| `trackCorrected`       | `bool`   | Whether the track name was auto-corrected.         |
+| `artist`               | `string` | The artist name (possibly corrected).              |
+| `artistCorrected`      | `bool`   | Whether the artist name was auto-corrected.        |
+| `album`                | `string` | The album name (possibly corrected).               |
+| `albumCorrected`       | `bool`   | Whether the album name was auto-corrected.         |
+| `albumArtist`          | `string` | The album artist name (possibly corrected).        |
+| `albumArtistCorrected` | `bool`   | Whether the album artist was auto-corrected.       |
+| `timestamp`            | `int`    | The scrobble timestamp.                            |
+| `ignoredCode`          | `int`    | Ignored reason code (0 = not ignored).             |
+| `ignoredMessage`       | `string` | Human-readable ignored reason.                     |
+
+### Ignored Codes
+
+| Code | Meaning                      |
+|------|------------------------------|
+| 0    | Not ignored (accepted).      |
+| 1    | Artist was ignored.          |
+| 2    | Track was ignored.           |
+| 3    | Timestamp was too old.       |
+| 4    | Timestamp was too new.       |
+| 5    | Daily scrobble limit exceeded.|
+
+## Examples
+
+### Checking Scrobble Results
+
+```php
+$result = $client->track()->scrobble(new Scrobble(
+    artist: 'Radiohead',
+    track: 'Karma Police',
+    timestamp: time(),
+));
+
+foreach ($result->scrobbles as $scrobble) {
+    if ($scrobble->ignoredCode > 0) {
+        echo "Ignored: {$scrobble->ignoredMessage}\n";
+        continue;
+    }
+
+    echo "Scrobbled: {$scrobble->artist} - {$scrobble->track}\n";
+
+    if ($scrobble->artistCorrected) {
+        echo "  (artist name was corrected)\n";
+    }
+}
+```
+
+### Full Scrobble with All Options
+
+```php
+$result = $client->track()->scrobble(new Scrobble(
+    artist: 'Radiohead',
+    track: 'Karma Police',
+    timestamp: time(),
+    album: 'OK Computer',
+    albumArtist: 'Radiohead',
+    trackNumber: 6,
+    duration: 264,
+    chosenByUser: true,
+));
+```

--- a/src/Dto/Scrobble.php
+++ b/src/Dto/Scrobble.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Dto;
+
+/**
+ * Represents a single scrobble to submit.
+ */
+final readonly class Scrobble
+{
+    public function __construct(
+        public string $artist,
+        public string $track,
+        public int $timestamp,
+        public ?string $album = null,
+        public ?string $albumArtist = null,
+        public ?int $trackNumber = null,
+        public ?string $mbid = null,
+        public ?int $duration = null,
+        public ?bool $chosenByUser = null,
+    ) {
+    }
+
+    /**
+     * Convert to API parameters for a given batch index.
+     *
+     * @return array<string, string>
+     */
+    public function toParams(int $index): array
+    {
+        $params = [
+            "artist[{$index}]" => $this->artist,
+            "track[{$index}]" => $this->track,
+            "timestamp[{$index}]" => (string) $this->timestamp,
+        ];
+
+        if ($this->album !== null) {
+            $params["album[{$index}]"] = $this->album;
+        }
+
+        if ($this->albumArtist !== null) {
+            $params["albumArtist[{$index}]"] = $this->albumArtist;
+        }
+
+        if ($this->trackNumber !== null) {
+            $params["trackNumber[{$index}]"] = (string) $this->trackNumber;
+        }
+
+        if ($this->mbid !== null) {
+            $params["mbid[{$index}]"] = $this->mbid;
+        }
+
+        if ($this->duration !== null) {
+            $params["duration[{$index}]"] = (string) $this->duration;
+        }
+
+        if ($this->chosenByUser !== null) {
+            $params["chosenByUser[{$index}]"] = $this->chosenByUser ? '1' : '0';
+        }
+
+        return $params;
+    }
+}

--- a/src/Dto/ScrobbleResponseDto.php
+++ b/src/Dto/ScrobbleResponseDto.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Dto;
+
+final readonly class ScrobbleResponseDto
+{
+    /**
+     * @param list<ScrobbleResultDto> $scrobbles
+     */
+    public function __construct(
+        public int $accepted,
+        public int $ignored,
+        public array $scrobbles,
+    ) {
+    }
+}

--- a/src/Dto/ScrobbleResultDto.php
+++ b/src/Dto/ScrobbleResultDto.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Dto;
+
+use Rjds\PhpDto\Attribute\CastTo;
+use Rjds\PhpDto\Attribute\MapFrom;
+
+final readonly class ScrobbleResultDto
+{
+    public function __construct(
+        #[MapFrom('track.#text')]
+        public string $track,
+        #[MapFrom('track.corrected')]
+        #[CastTo('bool')]
+        public bool $trackCorrected,
+        #[MapFrom('artist.#text')]
+        public string $artist,
+        #[MapFrom('artist.corrected')]
+        #[CastTo('bool')]
+        public bool $artistCorrected,
+        #[MapFrom('album.#text')]
+        public string $album,
+        #[MapFrom('album.corrected')]
+        #[CastTo('bool')]
+        public bool $albumCorrected,
+        #[MapFrom('albumArtist.#text')]
+        public string $albumArtist,
+        #[MapFrom('albumArtist.corrected')]
+        #[CastTo('bool')]
+        public bool $albumArtistCorrected,
+        #[CastTo('int')]
+        public int $timestamp,
+        #[MapFrom('ignoredMessage.code')]
+        #[CastTo('int')]
+        public int $ignoredCode,
+        #[MapFrom('ignoredMessage.#text')]
+        public string $ignoredMessage,
+    ) {
+    }
+}

--- a/src/Http/HttpClientInterface.php
+++ b/src/Http/HttpClientInterface.php
@@ -12,4 +12,13 @@ interface HttpClientInterface
      * @throws \RuntimeException on network or connection errors
      */
     public function get(string $url): string;
+
+    /**
+     * Perform a POST request with form data and return the response body.
+     *
+     * @param array<string, string> $data Form data to send
+     *
+     * @throws \RuntimeException on network or connection errors
+     */
+    public function post(string $url, array $data): string;
 }

--- a/src/Http/LastfmHttpClient.php
+++ b/src/Http/LastfmHttpClient.php
@@ -24,4 +24,25 @@ final class LastfmHttpClient implements HttpClientInterface
 
         return $response;
     }
+
+    public function post(string $url, array $data): string
+    {
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'POST',
+                'ignore_errors' => true,
+                'header' => "User-Agent: php-lastfm-client/1.0\r\n"
+                    . "Content-Type: application/x-www-form-urlencoded\r\n",
+                'content' => http_build_query($data),
+            ],
+        ]);
+
+        $response = file_get_contents($url, false, $context);
+
+        if ($response === false) {
+            throw new \RuntimeException('Failed to perform HTTP POST request to: ' . $url);
+        }
+
+        return $response;
+    }
 }

--- a/src/LastfmClient.php
+++ b/src/LastfmClient.php
@@ -8,6 +8,7 @@ use Rjds\PhpLastfmClient\Exception\LastfmApiException;
 use Rjds\PhpLastfmClient\Http\HttpClientInterface;
 use Rjds\PhpLastfmClient\Http\LastfmHttpClient;
 use Rjds\PhpLastfmClient\Service\LibraryService;
+use Rjds\PhpLastfmClient\Service\TrackService;
 use Rjds\PhpLastfmClient\Service\UserService;
 
 final class LastfmClient
@@ -17,6 +18,8 @@ final class LastfmClient
     public function __construct(
         private readonly string $apiKey,
         private readonly HttpClientInterface $httpClient = new LastfmHttpClient(),
+        private readonly ?string $apiSecret = null,
+        private readonly ?string $sessionKey = null,
     ) {
     }
 
@@ -37,7 +40,15 @@ final class LastfmClient
     }
 
     /**
-     * Make a raw API call to the Last.fm API.
+     * Access track-related API methods.
+     */
+    public function track(): TrackService
+    {
+        return new TrackService($this);
+    }
+
+    /**
+     * Make a raw GET API call to the Last.fm API.
      *
      * @param string $method The API method (e.g. 'user.getinfo')
      * @param array<string, string> $params Additional query parameters
@@ -57,6 +68,80 @@ final class LastfmClient
 
         $body = $this->httpClient->get($url);
 
+        return $this->decodeResponse($body);
+    }
+
+    /**
+     * Make an authenticated POST API call to the Last.fm API.
+     *
+     * Generates the required API signature and includes the session key.
+     *
+     * @param string $method The API method (e.g. 'track.scrobble')
+     * @param array<string, string> $params Additional parameters
+     * @return array<string, mixed> The decoded JSON response
+     *
+     * @throws \RuntimeException when API secret or session key is not configured
+     * @throws LastfmApiException when the API returns an error
+     */
+    public function callAuthenticated(string $method, array $params = []): array
+    {
+        if ($this->apiSecret === null) {
+            throw new \RuntimeException(
+                'API secret is required for authenticated calls.'
+            );
+        }
+
+        if ($this->sessionKey === null) {
+            throw new \RuntimeException(
+                'Session key is required for authenticated calls.'
+            );
+        }
+
+        $params = array_merge($params, [
+            'method' => $method,
+            'api_key' => $this->apiKey,
+            'sk' => $this->sessionKey,
+        ]);
+
+        $params['api_sig'] = $this->generateSignature($params);
+        $params['format'] = 'json';
+
+        $body = $this->httpClient->post(self::BASE_URL, $params);
+
+        return $this->decodeResponse($body);
+    }
+
+    /**
+     * Generate an API method signature.
+     *
+     * @param array<string, string> $params Parameters to sign (excluding 'format')
+     *
+     * @see https://www.last.fm/api/authspec#_8-signing-calls
+     */
+    private function generateSignature(array $params): string
+    {
+        ksort($params);
+
+        $signature = '';
+        foreach ($params as $key => $value) {
+            $signature .= $key . $value;
+        }
+
+        $signature .= $this->apiSecret;
+
+        return md5($signature);
+    }
+
+    /**
+     * Decode and validate a JSON response from the Last.fm API.
+     *
+     * @return array<string, mixed>
+     *
+     * @throws \RuntimeException when the response cannot be decoded
+     * @throws LastfmApiException when the API returns an error
+     */
+    private function decodeResponse(string $body): array
+    {
         $data = json_decode($body, true);
 
         if (!is_array($data)) {

--- a/src/Service/TrackService.php
+++ b/src/Service/TrackService.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Service;
+
+use Rjds\PhpDto\DtoMapper;
+use Rjds\PhpLastfmClient\Dto\Scrobble;
+use Rjds\PhpLastfmClient\Dto\ScrobbleResponseDto;
+use Rjds\PhpLastfmClient\Dto\ScrobbleResultDto;
+use Rjds\PhpLastfmClient\LastfmClient;
+
+final readonly class TrackService
+{
+    public function __construct(
+        private LastfmClient $client,
+        private DtoMapper $mapper = new DtoMapper(),
+    ) {
+    }
+
+    /**
+     * Scrobble a single track.
+     *
+     * @see https://www.last.fm/api/show/track.scrobble
+     */
+    public function scrobble(Scrobble $scrobble): ScrobbleResponseDto
+    {
+        return $this->scrobbleBatch([$scrobble]);
+    }
+
+    /**
+     * Scrobble a batch of tracks (up to 50).
+     *
+     * @param list<Scrobble> $scrobbles The scrobbles to submit
+     *
+     * @throws \InvalidArgumentException when the batch is empty or exceeds 50
+     *
+     * @see https://www.last.fm/api/show/track.scrobble
+     */
+    public function scrobbleBatch(array $scrobbles): ScrobbleResponseDto
+    {
+        if (count($scrobbles) === 0) {
+            throw new \InvalidArgumentException('At least one scrobble is required.');
+        }
+
+        if (count($scrobbles) > 50) {
+            throw new \InvalidArgumentException(
+                'A maximum of 50 scrobbles can be sent per batch.'
+            );
+        }
+
+        $params = [];
+        foreach ($scrobbles as $index => $scrobble) {
+            $params = array_merge($params, $scrobble->toParams($index));
+        }
+
+        $response = $this->client->callAuthenticated('track.scrobble', $params);
+
+        /** @var array<string, mixed> $scrobblesData */
+        $scrobblesData = $response['scrobbles'];
+
+        /** @var array{accepted: int, ignored: int} $attr */
+        $attr = $scrobblesData['@attr'];
+
+        $accepted = $attr['accepted'];
+        $ignored = $attr['ignored'];
+
+        /** @var array<string, mixed>|list<array<string, mixed>> $scrobbleData */
+        $scrobbleData = $scrobblesData['scrobble'];
+
+        // Single scrobble returns an object, batch returns an array
+        if (!array_is_list($scrobbleData)) {
+            $scrobbleData = [$scrobbleData];
+        }
+
+        /** @var list<ScrobbleResultDto> $results */
+        $results = [];
+        foreach ($scrobbleData as $item) {
+            /** @var array<string, mixed> $item */
+            $results[] = $this->mapper->map($item, ScrobbleResultDto::class);
+        }
+
+        return new ScrobbleResponseDto($accepted, $ignored, $results);
+    }
+}

--- a/tests/Dto/ScrobbleResponseDtoTest.php
+++ b/tests/Dto/ScrobbleResponseDtoTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Tests\Dto;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Rjds\PhpLastfmClient\Dto\ScrobbleResponseDto;
+use Rjds\PhpLastfmClient\Dto\ScrobbleResultDto;
+
+final class ScrobbleResponseDtoTest extends TestCase
+{
+    #[Test]
+    public function itHoldsAcceptedIgnoredAndResults(): void
+    {
+        $result = new ScrobbleResultDto(
+            track: 'Test',
+            trackCorrected: false,
+            artist: 'Artist',
+            artistCorrected: false,
+            album: '',
+            albumCorrected: false,
+            albumArtist: '',
+            albumArtistCorrected: false,
+            timestamp: 1287140447,
+            ignoredCode: 0,
+            ignoredMessage: '',
+        );
+
+        $response = new ScrobbleResponseDto(1, 0, [$result]);
+
+        $this->assertSame(1, $response->accepted);
+        $this->assertSame(0, $response->ignored);
+        $this->assertCount(1, $response->scrobbles);
+        $this->assertSame('Test', $response->scrobbles[0]->track);
+    }
+}

--- a/tests/Dto/ScrobbleResultDtoTest.php
+++ b/tests/Dto/ScrobbleResultDtoTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Tests\Dto;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Rjds\PhpDto\DtoMapper;
+use Rjds\PhpLastfmClient\Dto\ScrobbleResultDto;
+
+final class ScrobbleResultDtoTest extends TestCase
+{
+    private DtoMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new DtoMapper();
+    }
+
+    #[Test]
+    public function itMapsFromApiResponse(): void
+    {
+        $data = [
+            'track' => ['corrected' => '0', '#text' => 'Test Track'],
+            'artist' => ['corrected' => '0', '#text' => 'Test Artist'],
+            'album' => ['corrected' => '0', '#text' => ''],
+            'albumArtist' => ['corrected' => '0', '#text' => ''],
+            'timestamp' => '1287140447',
+            'ignoredMessage' => ['code' => '0', '#text' => ''],
+        ];
+
+        $dto = $this->mapper->map($data, ScrobbleResultDto::class);
+
+        $this->assertSame('Test Track', $dto->track);
+        $this->assertFalse($dto->trackCorrected);
+        $this->assertSame('Test Artist', $dto->artist);
+        $this->assertFalse($dto->artistCorrected);
+        $this->assertSame('', $dto->album);
+        $this->assertFalse($dto->albumCorrected);
+        $this->assertSame('', $dto->albumArtist);
+        $this->assertFalse($dto->albumArtistCorrected);
+        $this->assertSame(1287140447, $dto->timestamp);
+        $this->assertSame(0, $dto->ignoredCode);
+        $this->assertSame('', $dto->ignoredMessage);
+    }
+
+    #[Test]
+    public function itDetectsCorrections(): void
+    {
+        $data = [
+            'track' => ['corrected' => '1', '#text' => 'Corrected Track'],
+            'artist' => ['corrected' => '1', '#text' => 'Corrected Artist'],
+            'album' => ['corrected' => '0', '#text' => 'Album'],
+            'albumArtist' => ['corrected' => '0', '#text' => ''],
+            'timestamp' => '1287140447',
+            'ignoredMessage' => ['code' => '0', '#text' => ''],
+        ];
+
+        $dto = $this->mapper->map($data, ScrobbleResultDto::class);
+
+        $this->assertTrue($dto->trackCorrected);
+        $this->assertTrue($dto->artistCorrected);
+    }
+
+    #[Test]
+    public function itMapsIgnoredMessage(): void
+    {
+        $data = [
+            'track' => ['corrected' => '0', '#text' => 'Test Track'],
+            'artist' => ['corrected' => '0', '#text' => 'Test Artist'],
+            'album' => ['corrected' => '0', '#text' => ''],
+            'albumArtist' => ['corrected' => '0', '#text' => ''],
+            'timestamp' => '1287140447',
+            'ignoredMessage' => ['code' => '3', '#text' => 'Timestamp too old'],
+        ];
+
+        $dto = $this->mapper->map($data, ScrobbleResultDto::class);
+
+        $this->assertSame(3, $dto->ignoredCode);
+        $this->assertSame('Timestamp too old', $dto->ignoredMessage);
+    }
+}

--- a/tests/Dto/ScrobbleTest.php
+++ b/tests/Dto/ScrobbleTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Tests\Dto;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Rjds\PhpLastfmClient\Dto\Scrobble;
+
+final class ScrobbleTest extends TestCase
+{
+    #[Test]
+    public function itConvertsRequiredFieldsToParams(): void
+    {
+        $scrobble = new Scrobble(
+            artist: 'Radiohead',
+            track: 'Karma Police',
+            timestamp: 1287140447,
+        );
+
+        $params = $scrobble->toParams(0);
+
+        $this->assertSame('Radiohead', $params['artist[0]']);
+        $this->assertSame('Karma Police', $params['track[0]']);
+        $this->assertSame('1287140447', $params['timestamp[0]']);
+        $this->assertCount(3, $params);
+    }
+
+    #[Test]
+    public function itConvertsAllOptionalFieldsToParams(): void
+    {
+        $scrobble = new Scrobble(
+            artist: 'Radiohead',
+            track: 'Karma Police',
+            timestamp: 1287140447,
+            album: 'OK Computer',
+            albumArtist: 'Radiohead',
+            trackNumber: 6,
+            mbid: 'abc-123',
+            duration: 264,
+            chosenByUser: true,
+        );
+
+        $params = $scrobble->toParams(2);
+
+        $this->assertSame('Radiohead', $params['artist[2]']);
+        $this->assertSame('Karma Police', $params['track[2]']);
+        $this->assertSame('1287140447', $params['timestamp[2]']);
+        $this->assertSame('OK Computer', $params['album[2]']);
+        $this->assertSame('Radiohead', $params['albumArtist[2]']);
+        $this->assertSame('6', $params['trackNumber[2]']);
+        $this->assertSame('abc-123', $params['mbid[2]']);
+        $this->assertSame('264', $params['duration[2]']);
+        $this->assertSame('1', $params['chosenByUser[2]']);
+        $this->assertCount(9, $params);
+    }
+
+    #[Test]
+    public function itOmitsNullOptionalFields(): void
+    {
+        $scrobble = new Scrobble(
+            artist: 'Radiohead',
+            track: 'Karma Police',
+            timestamp: 1287140447,
+            album: 'OK Computer',
+        );
+
+        $params = $scrobble->toParams(0);
+
+        $this->assertCount(4, $params);
+        $this->assertArrayNotHasKey('albumArtist[0]', $params);
+        $this->assertArrayNotHasKey('trackNumber[0]', $params);
+        $this->assertArrayNotHasKey('mbid[0]', $params);
+        $this->assertArrayNotHasKey('duration[0]', $params);
+        $this->assertArrayNotHasKey('chosenByUser[0]', $params);
+    }
+
+    #[Test]
+    public function itConvertsChosenByUserFalseToZero(): void
+    {
+        $scrobble = new Scrobble(
+            artist: 'Radiohead',
+            track: 'Karma Police',
+            timestamp: 1287140447,
+            chosenByUser: false,
+        );
+
+        $params = $scrobble->toParams(0);
+
+        $this->assertSame('0', $params['chosenByUser[0]']);
+    }
+
+    #[Test]
+    public function itUsesCorrectBatchIndex(): void
+    {
+        $scrobble = new Scrobble(
+            artist: 'Queen',
+            track: 'Bohemian Rhapsody',
+            timestamp: 1287140447,
+        );
+
+        $params = $scrobble->toParams(5);
+
+        $this->assertArrayHasKey('artist[5]', $params);
+        $this->assertArrayHasKey('track[5]', $params);
+        $this->assertArrayHasKey('timestamp[5]', $params);
+    }
+}

--- a/tests/LastfmClientTest.php
+++ b/tests/LastfmClientTest.php
@@ -10,6 +10,7 @@ use Rjds\PhpLastfmClient\Exception\LastfmApiException;
 use Rjds\PhpLastfmClient\Http\HttpClientInterface;
 use Rjds\PhpLastfmClient\LastfmClient;
 use Rjds\PhpLastfmClient\Service\LibraryService;
+use Rjds\PhpLastfmClient\Service\TrackService;
 use Rjds\PhpLastfmClient\Service\UserService;
 
 final class LastfmClientTest extends TestCase
@@ -28,6 +29,14 @@ final class LastfmClientTest extends TestCase
         $client = new LastfmClient('test-api-key');
 
         $this->assertInstanceOf(LibraryService::class, $client->library());
+    }
+
+    #[Test]
+    public function itReturnsTrackService(): void
+    {
+        $client = new LastfmClient('test-api-key');
+
+        $this->assertInstanceOf(TrackService::class, $client->track());
     }
 
     #[Test]
@@ -127,5 +136,142 @@ final class LastfmClientTest extends TestCase
 
         $this->assertSame(10, $exception->getApiErrorCode());
         $this->assertSame('Invalid API key', $exception->getMessage());
+    }
+
+    #[Test]
+    public function itCallsAuthenticatedWithSignatureAndSessionKey(): void
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->stringContains('audioscrobbler'),
+                $this->callback(function (array $data): bool {
+                    $this->assertSame('track.scrobble', $data['method']);
+                    $this->assertSame('my-key', $data['api_key']);
+                    $this->assertSame('my-session', $data['sk']);
+                    $this->assertSame('json', $data['format']);
+                    $this->assertArrayHasKey('api_sig', $data);
+                    $this->assertSame('testvalue', $data['custom']);
+
+                    return true;
+                }),
+            )
+            ->willReturn('{"scrobbles": {}}');
+
+        $client = new LastfmClient(
+            apiKey: 'my-key',
+            httpClient: $httpClient,
+            apiSecret: 'my-secret',
+            sessionKey: 'my-session',
+        );
+
+        $client->callAuthenticated('track.scrobble', ['custom' => 'testvalue']);
+    }
+
+    #[Test]
+    public function itGeneratesCorrectApiSignature(): void
+    {
+        $capturedData = [];
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->anything(),
+                $this->callback(function (array $data) use (&$capturedData): bool {
+                    $capturedData = $data;
+                    return true;
+                }),
+            )
+            ->willReturn('{"result": {}}');
+
+        $client = new LastfmClient(
+            apiKey: 'testkey',
+            httpClient: $httpClient,
+            apiSecret: 'testsecret',
+            sessionKey: 'testsk',
+        );
+
+        $client->callAuthenticated('test.method', ['foo' => 'bar']);
+
+        // Signature = md5 of sorted params (without format) + secret
+        // Params: api_key=testkey, foo=bar, method=test.method, sk=testsk
+        // Sorted: api_keytestkeyfoobarmethod..., etc.
+        $expected = md5(
+            'api_keytestkey'
+            . 'foobar'
+            . 'methodtest.method'
+            . 'sktestsk'
+            . 'testsecret'
+        );
+
+        $this->assertSame($expected, $capturedData['api_sig']);
+    }
+
+    #[Test]
+    public function itThrowsWhenApiSecretIsMissing(): void
+    {
+        $client = new LastfmClient('test-api-key');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('API secret is required');
+
+        $client->callAuthenticated('track.scrobble');
+    }
+
+    #[Test]
+    public function itThrowsWhenSessionKeyIsMissing(): void
+    {
+        $client = new LastfmClient(
+            apiKey: 'test-api-key',
+            apiSecret: 'secret',
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Session key is required');
+
+        $client->callAuthenticated('track.scrobble');
+    }
+
+    #[Test]
+    public function itHandlesApiErrorOnAuthenticatedPost(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $httpClient->method('post')
+            ->willReturn('{"error": 9, "message": "Invalid session key"}');
+
+        $client = new LastfmClient(
+            apiKey: 'key',
+            httpClient: $httpClient,
+            apiSecret: 'secret',
+            sessionKey: 'bad-sk',
+        );
+
+        $this->expectException(LastfmApiException::class);
+        $this->expectExceptionMessage('Invalid session key');
+        $this->expectExceptionCode(9);
+
+        $client->callAuthenticated('track.scrobble');
+    }
+
+    #[Test]
+    public function itHandlesInvalidJsonOnAuthenticatedPost(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $httpClient->method('post')
+            ->willReturn('not json');
+
+        $client = new LastfmClient(
+            apiKey: 'key',
+            httpClient: $httpClient,
+            apiSecret: 'secret',
+            sessionKey: 'sk',
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Failed to decode Last.fm API response');
+
+        $client->callAuthenticated('track.scrobble');
     }
 }

--- a/tests/Service/TrackServiceTest.php
+++ b/tests/Service/TrackServiceTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Tests\Service;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Rjds\PhpLastfmClient\Dto\Scrobble;
+use Rjds\PhpLastfmClient\Dto\ScrobbleResponseDto;
+use Rjds\PhpLastfmClient\Http\HttpClientInterface;
+use Rjds\PhpLastfmClient\LastfmClient;
+
+final class TrackServiceTest extends TestCase
+{
+    private function createAuthenticatedClient(
+        HttpClientInterface $httpClient,
+    ): LastfmClient {
+        return new LastfmClient(
+            apiKey: 'test-key',
+            httpClient: $httpClient,
+            apiSecret: 'test-secret',
+            sessionKey: 'test-sk',
+        );
+    }
+
+    #[Test]
+    public function itScrobblesSingleTrack(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $httpClient->method('post')
+            ->willReturn((string) json_encode(
+                self::singleScrobbleResponse()
+            ));
+
+        $client = $this->createAuthenticatedClient($httpClient);
+        $result = $client->track()->scrobble(new Scrobble(
+            artist: 'Test Artist',
+            track: 'Test Track',
+            timestamp: 1287140447,
+        ));
+
+        $this->assertInstanceOf(ScrobbleResponseDto::class, $result);
+        $this->assertSame(1, $result->accepted);
+        $this->assertSame(0, $result->ignored);
+        $this->assertCount(1, $result->scrobbles);
+        $this->assertSame('Test Track', $result->scrobbles[0]->track);
+        $this->assertSame('Test Artist', $result->scrobbles[0]->artist);
+    }
+
+    #[Test]
+    public function itScrobblesBatchOfTracks(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $httpClient->method('post')
+            ->willReturn((string) json_encode(
+                self::batchScrobbleResponse()
+            ));
+
+        $client = $this->createAuthenticatedClient($httpClient);
+        $result = $client->track()->scrobbleBatch([
+            new Scrobble('Artist 0', 'Track 0', 1287141093),
+            new Scrobble('Artist 1', 'Track 1', 1287141093),
+        ]);
+
+        $this->assertSame(2, $result->accepted);
+        $this->assertSame(0, $result->ignored);
+        $this->assertCount(2, $result->scrobbles);
+        $this->assertSame('Track 0', $result->scrobbles[0]->track);
+        $this->assertSame('Track 1', $result->scrobbles[1]->track);
+    }
+
+    #[Test]
+    public function itSendsCorrectParametersForBatch(): void
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->anything(),
+                $this->callback(function (array $data): bool {
+                    $this->assertSame('track.scrobble', $data['method']);
+                    $this->assertSame('Artist A', $data['artist[0]']);
+                    $this->assertSame('Track A', $data['track[0]']);
+                    $this->assertSame('100', $data['timestamp[0]']);
+                    $this->assertSame('Artist B', $data['artist[1]']);
+                    $this->assertSame('Track B', $data['track[1]']);
+                    $this->assertSame('200', $data['timestamp[1]']);
+
+                    return true;
+                }),
+            )
+            ->willReturn((string) json_encode(
+                self::batchScrobbleResponse()
+            ));
+
+        $client = $this->createAuthenticatedClient($httpClient);
+        $client->track()->scrobbleBatch([
+            new Scrobble('Artist A', 'Track A', 100),
+            new Scrobble('Artist B', 'Track B', 200),
+        ]);
+    }
+
+    #[Test]
+    public function itThrowsOnEmptyBatch(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $client = $this->createAuthenticatedClient($httpClient);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('At least one scrobble is required');
+
+        $client->track()->scrobbleBatch([]);
+    }
+
+    #[Test]
+    public function itAllowsExactlyFiftyScrobbles(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $httpClient->method('post')
+            ->willReturn((string) json_encode(
+                self::batchScrobbleResponse()
+            ));
+
+        $client = $this->createAuthenticatedClient($httpClient);
+
+        $scrobbles = [];
+        for ($i = 0; $i < 50; $i++) {
+            $scrobbles[] = new Scrobble('Artist', 'Track', 100 + $i);
+        }
+
+        $result = $client->track()->scrobbleBatch($scrobbles);
+
+        $this->assertInstanceOf(ScrobbleResponseDto::class, $result);
+    }
+
+    #[Test]
+    public function itThrowsWhenBatchExceedsFifty(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $client = $this->createAuthenticatedClient($httpClient);
+
+        $scrobbles = [];
+        for ($i = 0; $i < 51; $i++) {
+            $scrobbles[] = new Scrobble('Artist', 'Track', 100);
+        }
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('maximum of 50');
+
+        $client->track()->scrobbleBatch($scrobbles);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function singleScrobbleResponse(): array
+    {
+        return [
+            'scrobbles' => [
+                'scrobble' => [
+                    'track' => [
+                        'corrected' => '0',
+                        '#text' => 'Test Track',
+                    ],
+                    'artist' => [
+                        'corrected' => '0',
+                        '#text' => 'Test Artist',
+                    ],
+                    'album' => ['corrected' => '0', '#text' => ''],
+                    'albumArtist' => [
+                        'corrected' => '0',
+                        '#text' => '',
+                    ],
+                    'timestamp' => '1287140447',
+                    'ignoredMessage' => [
+                        'code' => '0',
+                        '#text' => '',
+                    ],
+                ],
+                '@attr' => [
+                    'accepted' => 1,
+                    'ignored' => 0,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function batchScrobbleResponse(): array
+    {
+        return [
+            'scrobbles' => [
+                'scrobble' => [
+                    self::scrobbleItem('Track 0', 'Artist 0'),
+                    self::scrobbleItem('Track 1', 'Artist 1'),
+                ],
+                '@attr' => [
+                    'accepted' => 2,
+                    'ignored' => 0,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function scrobbleItem(
+        string $track,
+        string $artist,
+    ): array {
+        return [
+            'track' => ['corrected' => '0', '#text' => $track],
+            'artist' => ['corrected' => '0', '#text' => $artist],
+            'album' => ['corrected' => '0', '#text' => ''],
+            'albumArtist' => ['corrected' => '0', '#text' => ''],
+            'timestamp' => '1287141093',
+            'ignoredMessage' => ['code' => '0', '#text' => ''],
+        ];
+    }
+}


### PR DESCRIPTION
Closes #10

## Summary

Implements the `track.scrobble` endpoint — the first authenticated write endpoint in the library. Supports single and batch scrobbling (up to 50 tracks per request).

## Changes

### HTTP Layer
- **`HttpClientInterface`** — added `post(string $url, array $data): string` method
- **`LastfmHttpClient`** — implemented `post()` using `file_get_contents` with form-encoded body

### Authentication (LastfmClient)
- Added optional `apiSecret` and `sessionKey` constructor parameters
- Added `callAuthenticated()` method for signed POST requests
- Added `generateSignature()` for [Last.fm API signing](https://www.last.fm/api/authspec#_8-signing-calls)
- Extracted `decodeResponse()` to share JSON decode + error handling between `call()` and `callAuthenticated()`

### DTOs
- **`Scrobble`** — value object for scrobble input with `toParams(int $index)` for batch array notation
- **`ScrobbleResultDto`** — maps individual scrobble results (corrections, ignored messages)
- **`ScrobbleResponseDto`** — wraps accepted/ignored counts and result list

### TrackService
- `scrobble(Scrobble)` — convenience for single scrobbles
- `scrobbleBatch(list<Scrobble>)` — batch scrobbling with validation (1-50 items)
- Handles Last.fm's single-object vs array response format

### Documentation
- Added `docs/track/scrobble.md` with auth setup, parameters, return types, ignored codes, and examples
- Updated README endpoint table

### Usage

```php
$client = new LastfmClient(
    apiKey: 'your-api-key',
    apiSecret: 'your-api-secret',
    sessionKey: 'user-session-key',
);

// Single scrobble
$result = $client->track()->scrobble(new Scrobble(
    artist: 'Radiohead',
    track: 'Karma Police',
    timestamp: time(),
    album: 'OK Computer',
));

// Batch scrobble
$result = $client->track()->scrobbleBatch([
    new Scrobble('Artist A', 'Track A', time() - 600),
    new Scrobble('Artist B', 'Track B', time() - 300),
]);

echo "Accepted: {$result->accepted}, Ignored: {$result->ignored}";
```
