### PR TITLE
feat: implement authentication methods (auth.getToken, auth.getSession)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ echo "Page {$result->pagination->page} of {$result->pagination->totalPages}";
 | `user`    | `getInfo`      | Get information about a user profile     | [View](docs/user/getInfo.md)             |
 | `library` | `getArtists`   | Get all artists in a user's library      | [View](docs/library/getArtists.md)       |
 | `track`   | `scrobble`     | Scrobble a track to a user's profile     | [View](docs/track/scrobble.md)           |
+| `auth`    | `getToken`     | Get a request token for authentication   | [View](docs/auth/authentication.md)      |
+| `auth`    | `getSession`   | Exchange an authorized token for session | [View](docs/auth/authentication.md)      |
+
+## Authentication
+
+For write methods (scrobbling, etc.), you need to authenticate. See the [authentication guide](docs/auth/authentication.md) for the full flow:
+
+```php
+$client = new LastfmClient(
+    apiKey: 'your-api-key',
+    apiSecret: 'your-api-secret',
+);
+
+$token = $client->auth()->getToken();
+$authUrl = $client->auth()->getAuthUrl($token);
+// User visits $authUrl and grants access...
+$session = $client->auth()->getSession($token);
+// Use $session->key for authenticated calls
+```
 
 ## Error Handling
 

--- a/docs/auth/authentication.md
+++ b/docs/auth/authentication.md
@@ -1,0 +1,114 @@
+# Authentication
+
+Some Last.fm API methods (e.g. scrobbling) require authentication. This library implements the [Last.fm desktop authentication flow](https://www.last.fm/api/desktopauth).
+
+**Last.fm API Reference:** [auth.getToken](https://lastfm-docs.github.io/api-docs/auth/getToken/), [auth.getSession](https://lastfm-docs.github.io/api-docs/auth/getSession/)
+
+## Prerequisites
+
+You need an **API key** and **API secret** (shared secret) from the [Last.fm API account page](https://www.last.fm/api/account/create).
+
+## Authentication Flow
+
+### Step 1: Get a Token
+
+```php
+use Rjds\PhpLastfmClient\LastfmClient;
+
+$client = new LastfmClient(
+    apiKey: 'your-api-key',
+    apiSecret: 'your-api-secret',
+);
+
+$token = $client->auth()->getToken();
+```
+
+### Step 2: Authorize the Token
+
+Direct the user to the authorization URL. They must grant access in their browser:
+
+```php
+$authUrl = $client->auth()->getAuthUrl($token);
+
+echo "Please visit: {$authUrl}\n";
+echo "Press Enter after authorizing...\n";
+```
+
+For web apps, you can pass a callback URL:
+
+```php
+$authUrl = $client->auth()->getAuthUrl($token, 'https://yourapp.com/callback');
+// User will be redirected back to your callback URL after authorizing
+```
+
+### Step 3: Get a Session Key
+
+After the user has authorized, exchange the token for a session key:
+
+```php
+$session = $client->auth()->getSession($token);
+
+echo "Authenticated as: {$session->name}\n";
+echo "Session key: {$session->key}\n";
+```
+
+**Save the session key** — it doesn't expire and can be reused for future requests.
+
+### Step 4: Use the Session Key
+
+Create a new client with the session key to make authenticated calls:
+
+```php
+$authenticatedClient = new LastfmClient(
+    apiKey: 'your-api-key',
+    apiSecret: 'your-api-secret',
+    sessionKey: $session->key,
+);
+
+// Now you can scrobble, love tracks, etc.
+$authenticatedClient->track()->scrobble(new Scrobble(
+    artist: 'Radiohead',
+    track: 'Karma Police',
+    timestamp: time(),
+));
+```
+
+## SessionDto Properties
+
+| Property     | Type     | Description                          |
+|--------------|----------|--------------------------------------|
+| `name`       | `string` | The authenticated user's username.   |
+| `key`        | `string` | The session key (save this!).        |
+| `subscriber` | `bool`   | Whether the user is a subscriber.    |
+
+## Complete Example
+
+```php
+use Rjds\PhpLastfmClient\LastfmClient;
+
+// 1. Create client with API credentials
+$client = new LastfmClient(
+    apiKey: 'your-api-key',
+    apiSecret: 'your-api-secret',
+);
+
+// 2. Get token
+$token = $client->auth()->getToken();
+
+// 3. User authorizes in browser
+$authUrl = $client->auth()->getAuthUrl($token);
+echo "Visit: {$authUrl}\n";
+
+// Wait for user to authorize...
+
+// 4. Exchange token for session
+$session = $client->auth()->getSession($token);
+echo "Session key: {$session->key}\n";
+
+// 5. Store the session key and use it for authenticated calls
+$authenticated = new LastfmClient(
+    apiKey: 'your-api-key',
+    apiSecret: 'your-api-secret',
+    sessionKey: $session->key,
+);
+```

--- a/src/Dto/SessionDto.php
+++ b/src/Dto/SessionDto.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Dto;
+
+use Rjds\PhpDto\Attribute\CastTo;
+
+final readonly class SessionDto
+{
+    public function __construct(
+        public string $name,
+        public string $key,
+        #[CastTo('bool')]
+        public bool $subscriber,
+    ) {
+    }
+}

--- a/src/LastfmClient.php
+++ b/src/LastfmClient.php
@@ -7,6 +7,7 @@ namespace Rjds\PhpLastfmClient;
 use Rjds\PhpLastfmClient\Exception\LastfmApiException;
 use Rjds\PhpLastfmClient\Http\HttpClientInterface;
 use Rjds\PhpLastfmClient\Http\LastfmHttpClient;
+use Rjds\PhpLastfmClient\Service\AuthService;
 use Rjds\PhpLastfmClient\Service\LibraryService;
 use Rjds\PhpLastfmClient\Service\TrackService;
 use Rjds\PhpLastfmClient\Service\UserService;
@@ -21,6 +22,14 @@ final class LastfmClient
         private readonly ?string $apiSecret = null,
         private readonly ?string $sessionKey = null,
     ) {
+    }
+
+    /**
+     * Access authentication-related API methods.
+     */
+    public function auth(): AuthService
+    {
+        return new AuthService($this);
     }
 
     /**
@@ -109,6 +118,50 @@ final class LastfmClient
         $body = $this->httpClient->post(self::BASE_URL, $params);
 
         return $this->decodeResponse($body);
+    }
+
+    /**
+     * Make a signed GET API call to the Last.fm API.
+     *
+     * Used for methods that require a signature but not a session key
+     * (e.g. auth.getSession).
+     *
+     * @param string $method The API method (e.g. 'auth.getSession')
+     * @param array<string, string> $params Additional parameters
+     * @return array<string, mixed> The decoded JSON response
+     *
+     * @throws \RuntimeException when API secret is not configured
+     * @throws LastfmApiException when the API returns an error
+     */
+    public function callSigned(string $method, array $params = []): array
+    {
+        if ($this->apiSecret === null) {
+            throw new \RuntimeException(
+                'API secret is required for signed calls.'
+            );
+        }
+
+        $params = array_merge($params, [
+            'method' => $method,
+            'api_key' => $this->apiKey,
+        ]);
+
+        $params['api_sig'] = $this->generateSignature($params);
+        $params['format'] = 'json';
+
+        $url = self::BASE_URL . '?' . http_build_query($params);
+
+        $body = $this->httpClient->get($url);
+
+        return $this->decodeResponse($body);
+    }
+
+    /**
+     * Get the API key.
+     */
+    public function getApiKey(): string
+    {
+        return $this->apiKey;
     }
 
     /**

--- a/src/Service/AuthService.php
+++ b/src/Service/AuthService.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Service;
+
+use Rjds\PhpDto\DtoMapper;
+use Rjds\PhpLastfmClient\Dto\SessionDto;
+use Rjds\PhpLastfmClient\LastfmClient;
+
+final readonly class AuthService
+{
+    private const string AUTH_URL = 'https://www.last.fm/api/auth/';
+
+    public function __construct(
+        private LastfmClient $client,
+        private DtoMapper $mapper = new DtoMapper(),
+    ) {
+    }
+
+    /**
+     * Get an unauthorized request token.
+     *
+     * This is the first step in the authentication flow.
+     *
+     * @see https://lastfm-docs.github.io/api-docs/auth/getToken/
+     */
+    public function getToken(): string
+    {
+        $response = $this->client->call('auth.gettoken');
+
+        /** @var string $token */
+        $token = $response['token'];
+
+        return $token;
+    }
+
+    /**
+     * Build the URL the user must visit to authorize the token.
+     *
+     * This is the second step in the authentication flow.
+     * After the user visits this URL and grants access,
+     * you can exchange the token for a session key.
+     *
+     * @param string $token The token from getToken()
+     * @param string|null $callbackUrl Optional callback URL for web apps
+     */
+    public function getAuthUrl(string $token, ?string $callbackUrl = null): string
+    {
+        $params = [
+            'api_key' => $this->client->getApiKey(),
+            'token' => $token,
+        ];
+
+        if ($callbackUrl !== null) {
+            $params['cb'] = $callbackUrl;
+        }
+
+        return self::AUTH_URL . '?' . http_build_query($params);
+    }
+
+    /**
+     * Exchange an authorized token for a session key.
+     *
+     * This is the third step in the authentication flow.
+     * The user must have authorized the token at the URL
+     * returned by getAuthUrl() before calling this method.
+     *
+     * @param string $token The authorized token
+     *
+     * @see https://lastfm-docs.github.io/api-docs/auth/getSession/
+     */
+    public function getSession(string $token): SessionDto
+    {
+        $response = $this->client->callSigned('auth.getsession', [
+            'token' => $token,
+        ]);
+
+        /** @var array<string, mixed> $sessionData */
+        $sessionData = $response['session'];
+
+        return $this->mapper->map($sessionData, SessionDto::class);
+    }
+}

--- a/tests/Dto/SessionDtoTest.php
+++ b/tests/Dto/SessionDtoTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Tests\Dto;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Rjds\PhpDto\DtoMapper;
+use Rjds\PhpLastfmClient\Dto\SessionDto;
+
+final class SessionDtoTest extends TestCase
+{
+    #[Test]
+    public function itMapsFromApiResponse(): void
+    {
+        $mapper = new DtoMapper();
+
+        $dto = $mapper->map([
+            'name' => 'RubenJ01',
+            'key' => 'abc123sessionkey',
+            'subscriber' => '0',
+        ], SessionDto::class);
+
+        $this->assertSame('RubenJ01', $dto->name);
+        $this->assertSame('abc123sessionkey', $dto->key);
+        $this->assertFalse($dto->subscriber);
+    }
+
+    #[Test]
+    public function itMapsSubscriberTrue(): void
+    {
+        $mapper = new DtoMapper();
+
+        $dto = $mapper->map([
+            'name' => 'RubenJ01',
+            'key' => 'abc123',
+            'subscriber' => '1',
+        ], SessionDto::class);
+
+        $this->assertTrue($dto->subscriber);
+    }
+}

--- a/tests/LastfmClientTest.php
+++ b/tests/LastfmClientTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Rjds\PhpLastfmClient\Exception\LastfmApiException;
 use Rjds\PhpLastfmClient\Http\HttpClientInterface;
 use Rjds\PhpLastfmClient\LastfmClient;
+use Rjds\PhpLastfmClient\Service\AuthService;
 use Rjds\PhpLastfmClient\Service\LibraryService;
 use Rjds\PhpLastfmClient\Service\TrackService;
 use Rjds\PhpLastfmClient\Service\UserService;
@@ -273,5 +274,102 @@ final class LastfmClientTest extends TestCase
         $this->expectExceptionMessage('Failed to decode Last.fm API response');
 
         $client->callAuthenticated('track.scrobble');
+    }
+
+    #[Test]
+    public function itReturnsAuthService(): void
+    {
+        $client = new LastfmClient('test-api-key');
+
+        $this->assertInstanceOf(AuthService::class, $client->auth());
+    }
+
+    #[Test]
+    public function itExposesApiKey(): void
+    {
+        $client = new LastfmClient('my-special-key');
+
+        $this->assertSame('my-special-key', $client->getApiKey());
+    }
+
+    #[Test]
+    public function itCallsSignedWithSignatureButNoSessionKey(): void
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('get')
+            ->with($this->callback(function (string $url): bool {
+                $host = parse_url($url, PHP_URL_HOST);
+                $this->assertSame('ws.audioscrobbler.com', $host);
+
+                $query = parse_url($url, PHP_URL_QUERY);
+                $this->assertIsString($query);
+                parse_str((string) $query, $params);
+                $this->assertSame('auth.getsession', $params['method']);
+                $this->assertSame('test-key', $params['api_key']);
+                $this->assertArrayHasKey('api_sig', $params);
+                $this->assertSame('json', $params['format']);
+                $this->assertArrayNotHasKey('sk', $params);
+
+                return true;
+            }))
+            ->willReturn('{"session": {}}');
+
+        $client = new LastfmClient(
+            apiKey: 'test-key',
+            httpClient: $httpClient,
+            apiSecret: 'test-secret',
+        );
+
+        $client->callSigned('auth.getsession', ['token' => 'tok']);
+    }
+
+    #[Test]
+    public function itGeneratesCorrectSignatureForSignedCalls(): void
+    {
+        $capturedUrl = '';
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('get')
+            ->with($this->callback(
+                function (string $url) use (&$capturedUrl): bool {
+                    $capturedUrl = $url;
+                    return true;
+                },
+            ))
+            ->willReturn('{"result": {}}');
+
+        $client = new LastfmClient(
+            apiKey: 'testkey',
+            httpClient: $httpClient,
+            apiSecret: 'testsecret',
+        );
+
+        $client->callSigned('auth.getsession', ['token' => 'tok123']);
+
+        $query = parse_url($capturedUrl, PHP_URL_QUERY);
+        $this->assertIsString($query);
+        parse_str((string) $query, $params);
+
+        $expected = md5(
+            'api_keytestkey'
+            . 'methodauth.getsession'
+            . 'tokentok123'
+            . 'testsecret'
+        );
+
+        $this->assertSame($expected, $params['api_sig']);
+    }
+
+    #[Test]
+    public function itThrowsWhenApiSecretMissingForSignedCalls(): void
+    {
+        $client = new LastfmClient('test-key');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('API secret is required');
+
+        $client->callSigned('auth.getsession');
     }
 }

--- a/tests/Service/AuthServiceTest.php
+++ b/tests/Service/AuthServiceTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Tests\Service;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Rjds\PhpLastfmClient\Dto\SessionDto;
+use Rjds\PhpLastfmClient\Http\HttpClientInterface;
+use Rjds\PhpLastfmClient\LastfmClient;
+
+final class AuthServiceTest extends TestCase
+{
+    #[Test]
+    public function itGetsToken(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $httpClient->method('get')
+            ->willReturn('{"token": "abc123token"}');
+
+        $client = new LastfmClient('test-key', $httpClient);
+        $token = $client->auth()->getToken();
+
+        $this->assertSame('abc123token', $token);
+    }
+
+    #[Test]
+    public function itCallsGetTokenWithCorrectMethod(): void
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('get')
+            ->with($this->callback(function (string $url): bool {
+                $query = parse_url($url, PHP_URL_QUERY);
+                $this->assertIsString($query);
+                parse_str((string) $query, $params);
+                $this->assertSame('auth.gettoken', $params['method']);
+                $this->assertSame('test-key', $params['api_key']);
+
+                return true;
+            }))
+            ->willReturn('{"token": "abc123"}');
+
+        $client = new LastfmClient('test-key', $httpClient);
+        $client->auth()->getToken();
+    }
+
+    #[Test]
+    public function itBuildsAuthUrl(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $client = new LastfmClient('my-api-key', $httpClient);
+
+        $url = $client->auth()->getAuthUrl('mytoken');
+
+        $this->assertStringContainsString(
+            'https://www.last.fm/api/auth/',
+            $url,
+        );
+
+        $query = parse_url($url, PHP_URL_QUERY);
+        $this->assertIsString($query);
+        parse_str((string) $query, $params);
+        $this->assertSame('my-api-key', $params['api_key']);
+        $this->assertSame('mytoken', $params['token']);
+        $this->assertArrayNotHasKey('cb', $params);
+    }
+
+    #[Test]
+    public function itBuildsAuthUrlWithCallback(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $client = new LastfmClient('my-api-key', $httpClient);
+
+        $url = $client->auth()->getAuthUrl('mytoken', 'https://example.com/cb');
+
+        $query = parse_url($url, PHP_URL_QUERY);
+        $this->assertIsString($query);
+        parse_str((string) $query, $params);
+        $this->assertSame('https://example.com/cb', $params['cb']);
+    }
+
+    #[Test]
+    public function itGetsSession(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $httpClient->method('get')
+            ->willReturn((string) json_encode([
+                'session' => [
+                    'name' => 'RubenJ01',
+                    'key' => 'session-key-123',
+                    'subscriber' => '0',
+                ],
+            ]));
+
+        $client = new LastfmClient(
+            apiKey: 'test-key',
+            httpClient: $httpClient,
+            apiSecret: 'test-secret',
+        );
+
+        $session = $client->auth()->getSession('authorized-token');
+
+        $this->assertInstanceOf(SessionDto::class, $session);
+        $this->assertSame('RubenJ01', $session->name);
+        $this->assertSame('session-key-123', $session->key);
+        $this->assertFalse($session->subscriber);
+    }
+
+    #[Test]
+    public function itCallsGetSessionWithSignature(): void
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('get')
+            ->with($this->callback(function (string $url): bool {
+                $query = parse_url($url, PHP_URL_QUERY);
+                $this->assertIsString($query);
+                parse_str((string) $query, $params);
+                $this->assertSame('auth.getsession', $params['method']);
+                $this->assertSame('mytoken', $params['token']);
+                $this->assertArrayHasKey('api_sig', $params);
+                $this->assertSame('json', $params['format']);
+
+                return true;
+            }))
+            ->willReturn((string) json_encode([
+                'session' => [
+                    'name' => 'RubenJ01',
+                    'key' => 'sk',
+                    'subscriber' => '0',
+                ],
+            ]));
+
+        $client = new LastfmClient(
+            apiKey: 'test-key',
+            httpClient: $httpClient,
+            apiSecret: 'test-secret',
+        );
+
+        $client->auth()->getSession('mytoken');
+    }
+}


### PR DESCRIPTION
## Summary

Implements the Last.fm desktop authentication flow, making it easy to obtain tokens and session keys for authenticated API calls.

## Changes

### New Files
- `src/Service/AuthService.php` — getToken, getAuthUrl, getSession
- `src/Dto/SessionDto.php` — DTO for the auth.getSession response (name, key, subscriber)
- `docs/auth/authentication.md` — Full authentication guide with code examples
- `tests/Service/AuthServiceTest.php` — Tests for all auth service methods
- `tests/Dto/SessionDtoTest.php` — Tests for session DTO mapping

### Modified Files
- `src/LastfmClient.php` — Added callSigned for signed GET requests, getApiKey, and auth service accessor
- `tests/LastfmClientTest.php` — Tests for callSigned, getApiKey, and auth
- `README.md` — Added auth endpoints to table and authentication quick-start section

## Authentication Flow
1. `$client->auth()->getToken()` — get an unauthorized token
2. `$client->auth()->getAuthUrl($token)` — build URL for user to authorize
3. `$client->auth()->getSession($token)` — exchange authorized token for session key

## Quality
- PHPStan level 9
- PSR-12
- All tests passing
- 100% mutation score on LastfmClient.php

Closes #12
