### PR TITLE
refactor: organize DTOs into domain-specific subfolders

### DIFF
--- a/docs/auth/authentication.md
+++ b/docs/auth/authentication.md
@@ -59,6 +59,8 @@ echo "Session key: {$session->key}\n";
 Set the session key on the existing client, or create a new one:
 
 ```php
+use Rjds\PhpLastfmClient\Dto\Track\Scrobble;
+
 // Option A: set session key on the same client
 $client->setSessionKey($session->key);
 

--- a/docs/track/scrobble.md
+++ b/docs/track/scrobble.md
@@ -25,7 +25,7 @@ The client automatically generates the required API signature for each authentic
 ### Single Scrobble
 
 ```php
-use Rjds\PhpLastfmClient\Dto\Scrobble;
+use Rjds\PhpLastfmClient\Dto\Track\Scrobble;
 
 $result = $client->track()->scrobble(new Scrobble(
     artist: 'Radiohead',

--- a/src/Dto/Auth/SessionDto.php
+++ b/src/Dto/Auth/SessionDto.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Dto;
+namespace Rjds\PhpLastfmClient\Dto\Auth;
 
 use Rjds\PhpDto\Attribute\CastTo;
 

--- a/src/Dto/Common/ImageDto.php
+++ b/src/Dto/Common/ImageDto.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Dto;
+namespace Rjds\PhpLastfmClient\Dto\Common;
 
 use Rjds\PhpDto\Attribute\MapFrom;
 

--- a/src/Dto/Common/PaginatedResponse.php
+++ b/src/Dto/Common/PaginatedResponse.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Dto;
+namespace Rjds\PhpLastfmClient\Dto\Common;
 
 /**
  * A generic paginated response wrapper.

--- a/src/Dto/Common/PaginationDto.php
+++ b/src/Dto/Common/PaginationDto.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Dto;
+namespace Rjds\PhpLastfmClient\Dto\Common;
 
 use Rjds\PhpDto\Attribute\CastTo;
 

--- a/src/Dto/Library/LibraryArtistDto.php
+++ b/src/Dto/Library/LibraryArtistDto.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Dto;
+namespace Rjds\PhpLastfmClient\Dto\Library;
 
 use Rjds\PhpDto\Attribute\ArrayOf;
 use Rjds\PhpDto\Attribute\CastTo;
 use Rjds\PhpDto\Attribute\MapFrom;
+use Rjds\PhpLastfmClient\Dto\Common\ImageDto;
 
 final readonly class LibraryArtistDto
 {

--- a/src/Dto/Track/Scrobble.php
+++ b/src/Dto/Track/Scrobble.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Dto;
+namespace Rjds\PhpLastfmClient\Dto\Track;
 
 /**
  * Represents a single scrobble to submit.

--- a/src/Dto/Track/ScrobbleResponseDto.php
+++ b/src/Dto/Track/ScrobbleResponseDto.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Dto;
+namespace Rjds\PhpLastfmClient\Dto\Track;
 
 final readonly class ScrobbleResponseDto
 {

--- a/src/Dto/Track/ScrobbleResultDto.php
+++ b/src/Dto/Track/ScrobbleResultDto.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Dto;
+namespace Rjds\PhpLastfmClient\Dto\Track;
 
 use Rjds\PhpDto\Attribute\CastTo;
 use Rjds\PhpDto\Attribute\MapFrom;

--- a/src/Dto/User/UserDto.php
+++ b/src/Dto/User/UserDto.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Dto;
+namespace Rjds\PhpLastfmClient\Dto\User;
 
 use Rjds\PhpDto\Attribute\ArrayOf;
 use Rjds\PhpDto\Attribute\CastTo;
 use Rjds\PhpDto\Attribute\MapFrom;
+use Rjds\PhpLastfmClient\Dto\Common\ImageDto;
 
 final readonly class UserDto
 {

--- a/src/Service/AuthService.php
+++ b/src/Service/AuthService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Rjds\PhpLastfmClient\Service;
 
 use Rjds\PhpDto\DtoMapper;
-use Rjds\PhpLastfmClient\Dto\SessionDto;
+use Rjds\PhpLastfmClient\Dto\Auth\SessionDto;
 use Rjds\PhpLastfmClient\LastfmClient;
 
 final readonly class AuthService

--- a/src/Service/LibraryService.php
+++ b/src/Service/LibraryService.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Rjds\PhpLastfmClient\Service;
 
 use Rjds\PhpDto\DtoMapper;
-use Rjds\PhpLastfmClient\Dto\LibraryArtistDto;
-use Rjds\PhpLastfmClient\Dto\PaginatedResponse;
-use Rjds\PhpLastfmClient\Dto\PaginationDto;
+use Rjds\PhpLastfmClient\Dto\Common\PaginatedResponse;
+use Rjds\PhpLastfmClient\Dto\Common\PaginationDto;
+use Rjds\PhpLastfmClient\Dto\Library\LibraryArtistDto;
 use Rjds\PhpLastfmClient\LastfmClient;
 
 final readonly class LibraryService

--- a/src/Service/TrackService.php
+++ b/src/Service/TrackService.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Rjds\PhpLastfmClient\Service;
 
 use Rjds\PhpDto\DtoMapper;
-use Rjds\PhpLastfmClient\Dto\Scrobble;
-use Rjds\PhpLastfmClient\Dto\ScrobbleResponseDto;
-use Rjds\PhpLastfmClient\Dto\ScrobbleResultDto;
+use Rjds\PhpLastfmClient\Dto\Track\Scrobble;
+use Rjds\PhpLastfmClient\Dto\Track\ScrobbleResponseDto;
+use Rjds\PhpLastfmClient\Dto\Track\ScrobbleResultDto;
 use Rjds\PhpLastfmClient\LastfmClient;
 
 final readonly class TrackService

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Rjds\PhpLastfmClient\Service;
 
 use Rjds\PhpDto\DtoMapper;
-use Rjds\PhpLastfmClient\Dto\UserDto;
+use Rjds\PhpLastfmClient\Dto\User\UserDto;
 use Rjds\PhpLastfmClient\LastfmClient;
 
 final readonly class UserService

--- a/tests/Dto/Auth/SessionDtoTest.php
+++ b/tests/Dto/Auth/SessionDtoTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Tests\Dto;
+namespace Rjds\PhpLastfmClient\Tests\Dto\Auth;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Rjds\PhpDto\DtoMapper;
-use Rjds\PhpLastfmClient\Dto\SessionDto;
+use Rjds\PhpLastfmClient\Dto\Auth\SessionDto;
 
 final class SessionDtoTest extends TestCase
 {

--- a/tests/Dto/Common/ImageDtoTest.php
+++ b/tests/Dto/Common/ImageDtoTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Tests\Dto;
+namespace Rjds\PhpLastfmClient\Tests\Dto\Common;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Rjds\PhpDto\DtoMapper;
-use Rjds\PhpLastfmClient\Dto\ImageDto;
+use Rjds\PhpLastfmClient\Dto\Common\ImageDto;
 
 final class ImageDtoTest extends TestCase
 {

--- a/tests/Dto/Common/PaginatedResponseTest.php
+++ b/tests/Dto/Common/PaginatedResponseTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Tests\Dto;
+namespace Rjds\PhpLastfmClient\Tests\Dto\Common;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Rjds\PhpLastfmClient\Dto\PaginatedResponse;
-use Rjds\PhpLastfmClient\Dto\PaginationDto;
+use Rjds\PhpLastfmClient\Dto\Common\PaginatedResponse;
+use Rjds\PhpLastfmClient\Dto\Common\PaginationDto;
 
 final class PaginatedResponseTest extends TestCase
 {

--- a/tests/Dto/Common/PaginationDtoTest.php
+++ b/tests/Dto/Common/PaginationDtoTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Tests\Dto;
+namespace Rjds\PhpLastfmClient\Tests\Dto\Common;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Rjds\PhpDto\DtoMapper;
-use Rjds\PhpLastfmClient\Dto\PaginationDto;
+use Rjds\PhpLastfmClient\Dto\Common\PaginationDto;
 
 final class PaginationDtoTest extends TestCase
 {

--- a/tests/Dto/Library/LibraryArtistDtoTest.php
+++ b/tests/Dto/Library/LibraryArtistDtoTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Tests\Dto;
+namespace Rjds\PhpLastfmClient\Tests\Dto\Library;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Rjds\PhpDto\DtoMapper;
-use Rjds\PhpLastfmClient\Dto\ImageDto;
-use Rjds\PhpLastfmClient\Dto\LibraryArtistDto;
+use Rjds\PhpLastfmClient\Dto\Common\ImageDto;
+use Rjds\PhpLastfmClient\Dto\Library\LibraryArtistDto;
 
 final class LibraryArtistDtoTest extends TestCase
 {

--- a/tests/Dto/Track/ScrobbleResponseDtoTest.php
+++ b/tests/Dto/Track/ScrobbleResponseDtoTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Tests\Dto;
+namespace Rjds\PhpLastfmClient\Tests\Dto\Track;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Rjds\PhpLastfmClient\Dto\ScrobbleResponseDto;
-use Rjds\PhpLastfmClient\Dto\ScrobbleResultDto;
+use Rjds\PhpLastfmClient\Dto\Track\ScrobbleResponseDto;
+use Rjds\PhpLastfmClient\Dto\Track\ScrobbleResultDto;
 
 final class ScrobbleResponseDtoTest extends TestCase
 {

--- a/tests/Dto/Track/ScrobbleResultDtoTest.php
+++ b/tests/Dto/Track/ScrobbleResultDtoTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Tests\Dto;
+namespace Rjds\PhpLastfmClient\Tests\Dto\Track;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Rjds\PhpDto\DtoMapper;
-use Rjds\PhpLastfmClient\Dto\ScrobbleResultDto;
+use Rjds\PhpLastfmClient\Dto\Track\ScrobbleResultDto;
 
 final class ScrobbleResultDtoTest extends TestCase
 {

--- a/tests/Dto/Track/ScrobbleTest.php
+++ b/tests/Dto/Track/ScrobbleTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Tests\Dto;
+namespace Rjds\PhpLastfmClient\Tests\Dto\Track;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Rjds\PhpLastfmClient\Dto\Scrobble;
+use Rjds\PhpLastfmClient\Dto\Track\Scrobble;
 
 final class ScrobbleTest extends TestCase
 {

--- a/tests/Dto/User/UserDtoTest.php
+++ b/tests/Dto/User/UserDtoTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Rjds\PhpLastfmClient\Tests\Dto;
+namespace Rjds\PhpLastfmClient\Tests\Dto\User;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Rjds\PhpDto\DtoMapper;
-use Rjds\PhpLastfmClient\Dto\ImageDto;
-use Rjds\PhpLastfmClient\Dto\UserDto;
+use Rjds\PhpLastfmClient\Dto\Common\ImageDto;
+use Rjds\PhpLastfmClient\Dto\User\UserDto;
 
 final class UserDtoTest extends TestCase
 {

--- a/tests/Service/AuthServiceTest.php
+++ b/tests/Service/AuthServiceTest.php
@@ -6,7 +6,7 @@ namespace Rjds\PhpLastfmClient\Tests\Service;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Rjds\PhpLastfmClient\Dto\SessionDto;
+use Rjds\PhpLastfmClient\Dto\Auth\SessionDto;
 use Rjds\PhpLastfmClient\Http\HttpClientInterface;
 use Rjds\PhpLastfmClient\LastfmClient;
 

--- a/tests/Service/LibraryServiceTest.php
+++ b/tests/Service/LibraryServiceTest.php
@@ -6,8 +6,8 @@ namespace Rjds\PhpLastfmClient\Tests\Service;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Rjds\PhpLastfmClient\Dto\ImageDto;
-use Rjds\PhpLastfmClient\Dto\LibraryArtistDto;
+use Rjds\PhpLastfmClient\Dto\Common\ImageDto;
+use Rjds\PhpLastfmClient\Dto\Library\LibraryArtistDto;
 use Rjds\PhpLastfmClient\Http\HttpClientInterface;
 use Rjds\PhpLastfmClient\LastfmClient;
 

--- a/tests/Service/TrackServiceTest.php
+++ b/tests/Service/TrackServiceTest.php
@@ -6,8 +6,8 @@ namespace Rjds\PhpLastfmClient\Tests\Service;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Rjds\PhpLastfmClient\Dto\Scrobble;
-use Rjds\PhpLastfmClient\Dto\ScrobbleResponseDto;
+use Rjds\PhpLastfmClient\Dto\Track\Scrobble;
+use Rjds\PhpLastfmClient\Dto\Track\ScrobbleResponseDto;
 use Rjds\PhpLastfmClient\Http\HttpClientInterface;
 use Rjds\PhpLastfmClient\LastfmClient;
 

--- a/tests/Service/UserServiceTest.php
+++ b/tests/Service/UserServiceTest.php
@@ -6,7 +6,7 @@ namespace Rjds\PhpLastfmClient\Tests\Service;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Rjds\PhpLastfmClient\Dto\UserDto;
+use Rjds\PhpLastfmClient\Dto\User\UserDto;
 use Rjds\PhpLastfmClient\Http\HttpClientInterface;
 use Rjds\PhpLastfmClient\LastfmClient;
 


### PR DESCRIPTION
Closes #16

## Changes

Organizes DTOs into domain-specific subfolders to improve discoverability as the number of endpoints grows.

### New structure

```
src/Dto/
  Auth/SessionDto.php
  Common/ImageDto.php, PaginatedResponse.php, PaginationDto.php
  Library/LibraryArtistDto.php
  Track/Scrobble.php, ScrobbleResponseDto.php, ScrobbleResultDto.php
  User/UserDto.php
```

Tests mirror the same subfolder layout under `tests/Dto/`.

### Updated

- All DTO namespaces (`Rjds\PhpLastfmClient\Dto\{Domain}\...`)
- All `use` imports in services, tests, and the main client
- Documentation references in `docs/track/scrobble.md` and `docs/auth/authentication.md`

### Quality

- GrumPHP (phpcs, phpstan level 9, phpunit): all green
- Infection: 98% MSI (2 equivalent `CastString` mutants)
