### PR TITLE
fix: eliminate equivalent CastString mutants in LibraryService

### DIFF
--- a/src/Http/HttpClientInterface.php
+++ b/src/Http/HttpClientInterface.php
@@ -16,7 +16,7 @@ interface HttpClientInterface
     /**
      * Perform a POST request with form data and return the response body.
      *
-     * @param array<string, string> $data Form data to send
+     * @param array<string, string|int> $data Form data to send
      *
      * @throws \RuntimeException on network or connection errors
      */

--- a/src/Http/LastfmHttpClient.php
+++ b/src/Http/LastfmHttpClient.php
@@ -12,7 +12,7 @@ final class LastfmHttpClient implements HttpClientInterface
     }
 
     /**
-     * @param array<string, string> $data
+     * @param array<string, string|int> $data
      */
     public function post(string $url, array $data): string
     {

--- a/src/LastfmClient.php
+++ b/src/LastfmClient.php
@@ -83,7 +83,7 @@ final class LastfmClient
      * Make a GET API call to the Last.fm API.
      *
      * @param string $method The API method (e.g. 'user.getinfo')
-     * @param array<string, string> $params Additional query parameters
+     * @param array<string, string|int> $params Additional query parameters
      * @return array<string, mixed> The decoded JSON response
      *
      * @throws LastfmApiException when the API returns an error
@@ -105,7 +105,7 @@ final class LastfmClient
      * (e.g. auth.getSession).
      *
      * @param string $method The API method (e.g. 'auth.getSession')
-     * @param array<string, string> $params Additional parameters
+     * @param array<string, string|int> $params Additional parameters
      * @return array<string, mixed> The decoded JSON response
      *
      * @throws \RuntimeException when API secret is not configured
@@ -127,7 +127,7 @@ final class LastfmClient
      * Generates the required API signature and includes the session key.
      *
      * @param string $method The API method (e.g. 'track.scrobble')
-     * @param array<string, string> $params Additional parameters
+     * @param array<string, string|int> $params Additional parameters
      * @return array<string, mixed> The decoded JSON response
      *
      * @throws \RuntimeException when API secret or session key is not configured
@@ -157,8 +157,8 @@ final class LastfmClient
     /**
      * Merge base API parameters (method, api_key) into the given params.
      *
-     * @param array<string, string> $params
-     * @return array<string, string>
+     * @param array<string, string|int> $params
+     * @return array<string, string|int>
      */
     private function withBaseParams(string $method, array $params): array
     {
@@ -171,8 +171,8 @@ final class LastfmClient
     /**
      * Sign the parameters and add 'api_sig' and 'format'.
      *
-     * @param array<string, string> $params Parameters to sign (must not include 'format')
-     * @return array<string, string>
+     * @param array<string, string|int> $params Parameters to sign (must not include 'format')
+     * @return array<string, string|int>
      *
      * @throws \RuntimeException when API secret is not configured
      */

--- a/src/Service/LibraryService.php
+++ b/src/Service/LibraryService.php
@@ -29,8 +29,8 @@ final readonly class LibraryService
     {
         $response = $this->client->call('library.getartists', [
             'user' => $user,
-            'limit' => (string) $limit,
-            'page' => (string) $page,
+            'limit' => $limit,
+            'page' => $page,
         ]);
 
         /** @var array<string, mixed> $data */


### PR DESCRIPTION
Closes #18

Widens the params type from `array<string, string>` to `array<string, string|int>` across `call()`, `callSigned()`, `callAuthenticated()`, `HttpClientInterface::post()`, and related internal methods.

This lets `LibraryService` pass `limit` and `page` as native integers without `(string)` casts, eliminating the 2 equivalent CastString mutants.

**Infection: 100% MSI (108/108 mutants killed)**