### PR TITLE
feat: implement user.getLovedTracks endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ echo "Page {$result->pagination->page} of {$result->pagination->totalPages}";
 | Service   | Method         | Description                              | Docs                                     |
 |-----------|----------------|------------------------------------------|------------------------------------------|
 | `user`    | `getInfo`      | Get information about a user profile     | [View](docs/user/getInfo.md)             |
+| `user`    | `getLovedTracks` | Get a user's loved tracks              | [View](docs/user/getLovedTracks.md)      |
 | `library` | `getArtists`   | Get all artists in a user's library      | [View](docs/library/getArtists.md)       |
 | `track`   | `scrobble`     | Scrobble a track to a user's profile     | [View](docs/track/scrobble.md)           |
 | `auth`    | `getToken`     | Get a request token for authentication   | [View](docs/auth/authentication.md)      |

--- a/docs/user/getLovedTracks.md
+++ b/docs/user/getLovedTracks.md
@@ -1,0 +1,118 @@
+# user.getLovedTracks
+
+Get a paginated list of tracks loved by a user.
+
+**Last.fm API Reference:** [user.getLovedTracks](https://lastfm-docs.github.io/api-docs/user/getLovedTracks/)
+
+## Usage
+
+```php
+use Rjds\PhpLastfmClient\LastfmClient;
+
+$client = new LastfmClient('your-api-key');
+
+$result = $client->user()->getLovedTracks('rj');
+```
+
+## Parameters
+
+| Parameter | Type     | Required | Default | Description                              |
+|-----------|----------|----------|---------|------------------------------------------|
+| `$user`   | `string` | Yes      | —       | The username to fetch loved tracks for.  |
+| `$limit`  | `int`    | No       | `50`    | Number of results per page (max 1000).   |
+| `$page`   | `int`    | No       | `1`     | The page number to fetch.                |
+
+## Return Type
+
+Returns a `PaginatedResponse<LovedTrackDto>` object.
+
+### PaginatedResponse Properties
+
+| Property     | Type                    | Description                   |
+|--------------|-------------------------|-------------------------------|
+| `items`      | `list<LovedTrackDto>`   | The loved tracks on this page.|
+| `pagination` | `PaginationDto`         | Pagination metadata.          |
+
+### PaginationDto Properties
+
+| Property     | Type  | Description                      |
+|--------------|-------|----------------------------------|
+| `page`       | `int` | The current page number.         |
+| `perPage`    | `int` | Number of results per page.      |
+| `total`      | `int` | Total number of results.         |
+| `totalPages` | `int` | Total number of pages.           |
+
+### LovedTrackDto Properties
+
+| Property     | Type                | Description                                  |
+|--------------|---------------------|----------------------------------------------|
+| `name`       | `string`            | The track name.                              |
+| `url`        | `string`            | URL to the track's Last.fm page.             |
+| `mbid`       | `string`            | MusicBrainz Track ID.                        |
+| `artistName` | `string`            | The artist's name.                           |
+| `artistUrl`  | `string`            | URL to the artist's Last.fm page.            |
+| `artistMbid` | `string`            | MusicBrainz Artist ID.                       |
+| `lovedAt`    | `DateTimeImmutable` | When the track was loved.                    |
+| `images`     | `list<ImageDto>`    | Track images in various sizes.               |
+| `streamable` | `bool`              | Whether the track is streamable.             |
+
+### ImageDto Properties
+
+| Property | Type     | Description                                         |
+|----------|----------|-----------------------------------------------------|
+| `size`   | `string` | Image size (`"small"`, `"medium"`, `"large"`, etc). |
+| `url`    | `string` | URL to the image.                                   |
+
+## Examples
+
+### Basic Usage
+
+```php
+$result = $client->user()->getLovedTracks('rj');
+
+foreach ($result->items as $track) {
+    echo "{$track->artistName} - {$track->name}\n";
+}
+```
+
+### Pagination
+
+```php
+// Fetch page 3, 10 tracks per page
+$result = $client->user()->getLovedTracks('rj', limit: 10, page: 3);
+
+echo "Page {$result->pagination->page} of {$result->pagination->totalPages}\n";
+echo "Total loved tracks: {$result->pagination->total}\n";
+```
+
+### Accessing Track Details
+
+```php
+$result = $client->user()->getLovedTracks('rj', limit: 5);
+
+foreach ($result->items as $track) {
+    echo "{$track->artistName} - {$track->name}\n";
+    echo "  Loved at: {$track->lovedAt->format('Y-m-d H:i')}\n";
+    echo "  URL: {$track->url}\n";
+
+    foreach ($track->images as $image) {
+        echo "  {$image->size}: {$image->url}\n";
+    }
+}
+```
+
+### Iterating All Pages
+
+```php
+$page = 1;
+
+do {
+    $result = $client->user()->getLovedTracks('rj', limit: 100, page: $page);
+
+    foreach ($result->items as $track) {
+        echo "{$track->artistName} - {$track->name}\n";
+    }
+
+    $page++;
+} while ($page <= $result->pagination->totalPages);
+```

--- a/src/Dto/User/LovedTrackDto.php
+++ b/src/Dto/User/LovedTrackDto.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Dto\User;
+
+use Rjds\PhpDto\Attribute\ArrayOf;
+use Rjds\PhpDto\Attribute\CastTo;
+use Rjds\PhpDto\Attribute\MapFrom;
+use Rjds\PhpLastfmClient\Dto\Common\ImageDto;
+
+final readonly class LovedTrackDto
+{
+    /**
+     * @param list<ImageDto> $images
+     */
+    public function __construct(
+        public string $name,
+        public string $url,
+        public string $mbid,
+        #[MapFrom('artist.name')]
+        public string $artistName,
+        #[MapFrom('artist.url')]
+        public string $artistUrl,
+        #[MapFrom('artist.mbid')]
+        public string $artistMbid,
+        #[MapFrom('date.uts')]
+        #[CastTo('datetime')]
+        public \DateTimeImmutable $lovedAt,
+        #[MapFrom('image')]
+        #[ArrayOf(ImageDto::class)]
+        public array $images,
+        #[MapFrom('streamable.#text')]
+        #[CastTo('bool')]
+        public bool $streamable,
+    ) {
+    }
+}

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Rjds\PhpLastfmClient\Service;
 
 use Rjds\PhpDto\DtoMapper;
+use Rjds\PhpLastfmClient\Dto\Common\PaginatedResponse;
+use Rjds\PhpLastfmClient\Dto\Common\PaginationDto;
+use Rjds\PhpLastfmClient\Dto\User\LovedTrackDto;
 use Rjds\PhpLastfmClient\Dto\User\UserDto;
 use Rjds\PhpLastfmClient\LastfmClient;
 
@@ -29,5 +32,39 @@ final readonly class UserService
         $userData = $response['user'];
 
         return $this->mapper->map($userData, UserDto::class);
+    }
+
+    /**
+     * Get a paginated list of tracks loved by a user.
+     *
+     * @see https://lastfm-docs.github.io/api-docs/user/getLovedTracks/
+     *
+     * @return PaginatedResponse<LovedTrackDto>
+     */
+    public function getLovedTracks(string $user, int $limit = 50, int $page = 1): PaginatedResponse
+    {
+        $response = $this->client->call('user.getlovedtracks', [
+            'user' => $user,
+            'limit' => $limit,
+            'page' => $page,
+        ]);
+
+        /** @var array<string, mixed> $data */
+        $data = $response['lovedtracks'];
+
+        /** @var list<array<string, mixed>> $trackList */
+        $trackList = $data['track'];
+
+        /** @var list<LovedTrackDto> $tracks */
+        $tracks = [];
+        foreach ($trackList as $item) {
+            $tracks[] = $this->mapper->map($item, LovedTrackDto::class);
+        }
+
+        /** @var array<string, mixed> $attrData */
+        $attrData = $data['@attr'];
+        $pagination = $this->mapper->map($attrData, PaginationDto::class);
+
+        return new PaginatedResponse($tracks, $pagination);
     }
 }

--- a/tests/Dto/User/LovedTrackDtoTest.php
+++ b/tests/Dto/User/LovedTrackDtoTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Tests\Dto\User;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Rjds\PhpDto\DtoMapper;
+use Rjds\PhpLastfmClient\Dto\Common\ImageDto;
+use Rjds\PhpLastfmClient\Dto\User\LovedTrackDto;
+
+final class LovedTrackDtoTest extends TestCase
+{
+    private DtoMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new DtoMapper();
+    }
+
+    #[Test]
+    public function itMapsFromApiResponse(): void
+    {
+        $dto = $this->mapper->map(self::trackApiData(), LovedTrackDto::class);
+
+        $this->assertSame('Davy Crochet', $dto->name);
+        $this->assertSame(
+            'https://www.last.fm/music/The+Backseat+Lovers/_/Davy+Crochet',
+            $dto->url,
+        );
+        $this->assertSame('59da79dd-aed6-447c-951c-070f6b8446a1', $dto->mbid);
+    }
+
+    #[Test]
+    public function itMapsArtistFields(): void
+    {
+        $dto = $this->mapper->map(self::trackApiData(), LovedTrackDto::class);
+
+        $this->assertSame('The Backseat Lovers', $dto->artistName);
+        $this->assertSame(
+            'https://www.last.fm/music/The+Backseat+Lovers',
+            $dto->artistUrl,
+        );
+        $this->assertSame('artist-mbid-123', $dto->artistMbid);
+    }
+
+    #[Test]
+    public function itMapsLovedAtDate(): void
+    {
+        $dto = $this->mapper->map(self::trackApiData(), LovedTrackDto::class);
+
+        $this->assertSame(1603112664, $dto->lovedAt->getTimestamp());
+    }
+
+    #[Test]
+    public function itParsesImages(): void
+    {
+        $dto = $this->mapper->map(self::trackApiData(), LovedTrackDto::class);
+
+        $this->assertCount(2, $dto->images);
+        $this->assertInstanceOf(ImageDto::class, $dto->images[0]);
+        $this->assertSame('small', $dto->images[0]->size);
+        $this->assertSame(
+            'https://lastfm.freetls.fastly.net/i/u/34s/img.png',
+            $dto->images[0]->url,
+        );
+    }
+
+    #[Test]
+    public function itMapsStreamableField(): void
+    {
+        $dto = $this->mapper->map(self::trackApiData(), LovedTrackDto::class);
+
+        $this->assertFalse($dto->streamable);
+    }
+
+    #[Test]
+    public function itMapsStreamableTrue(): void
+    {
+        $data = self::trackApiData();
+        $data['streamable'] = ['fulltrack' => '1', '#text' => '1'];
+
+        $dto = $this->mapper->map($data, LovedTrackDto::class);
+
+        $this->assertTrue($dto->streamable);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function trackApiData(): array
+    {
+        return [
+            'name' => 'Davy Crochet',
+            'url' => 'https://www.last.fm/music/The+Backseat+Lovers/_/Davy+Crochet',
+            'mbid' => '59da79dd-aed6-447c-951c-070f6b8446a1',
+            'artist' => [
+                'name' => 'The Backseat Lovers',
+                'url' => 'https://www.last.fm/music/The+Backseat+Lovers',
+                'mbid' => 'artist-mbid-123',
+            ],
+            'date' => [
+                'uts' => '1603112664',
+                '#text' => '19 Oct 2020, 13:04',
+            ],
+            'image' => [
+                [
+                    'size' => 'small',
+                    '#text' => 'https://lastfm.freetls.fastly.net/i/u/34s/img.png',
+                ],
+                [
+                    'size' => 'large',
+                    '#text' => 'https://lastfm.freetls.fastly.net/i/u/174s/img.png',
+                ],
+            ],
+            'streamable' => [
+                'fulltrack' => '0',
+                '#text' => '0',
+            ],
+        ];
+    }
+}

--- a/tests/Service/UserServiceTest.php
+++ b/tests/Service/UserServiceTest.php
@@ -6,6 +6,8 @@ namespace Rjds\PhpLastfmClient\Tests\Service;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Rjds\PhpLastfmClient\Dto\Common\ImageDto;
+use Rjds\PhpLastfmClient\Dto\User\LovedTrackDto;
 use Rjds\PhpLastfmClient\Dto\User\UserDto;
 use Rjds\PhpLastfmClient\Http\HttpClientInterface;
 use Rjds\PhpLastfmClient\LastfmClient;
@@ -49,6 +51,112 @@ final class UserServiceTest extends TestCase
         $client->user()->getInfo('testuser');
     }
 
+    #[Test]
+    public function itReturnsLovedTracks(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $httpClient->method('get')
+            ->willReturn(
+                (string) json_encode(self::lovedTracksResponse())
+            );
+
+        $client = new LastfmClient('test-api-key', httpClient: $httpClient);
+        $result = $client->user()->getLovedTracks('rj');
+
+        $this->assertCount(2, $result->items);
+        $this->assertInstanceOf(LovedTrackDto::class, $result->items[0]);
+        $this->assertSame('Davy Crochet', $result->items[0]->name);
+        $this->assertSame('The Backseat Lovers', $result->items[0]->artistName);
+        $this->assertSame('Lucky', $result->items[1]->name);
+        $this->assertSame('Radiohead', $result->items[1]->artistName);
+    }
+
+    #[Test]
+    public function itReturnsPaginationForLovedTracks(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $httpClient->method('get')
+            ->willReturn(
+                (string) json_encode(self::lovedTracksResponse())
+            );
+
+        $client = new LastfmClient('test-api-key', httpClient: $httpClient);
+        $result = $client->user()->getLovedTracks('rj');
+
+        $this->assertSame(1, $result->pagination->page);
+        $this->assertSame(2, $result->pagination->perPage);
+        $this->assertSame(7790, $result->pagination->total);
+        $this->assertSame(3895, $result->pagination->totalPages);
+    }
+
+    #[Test]
+    public function itCallsGetLovedTracksWithCorrectParams(): void
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('get')
+            ->with($this->callback(function (string $url): bool {
+                $query = parse_url($url, PHP_URL_QUERY);
+                $this->assertIsString($query);
+                parse_str((string) $query, $params);
+                $this->assertSame('user.getlovedtracks', $params['method']);
+                $this->assertSame('testuser', $params['user']);
+                $this->assertSame('10', $params['limit']);
+                $this->assertSame('3', $params['page']);
+
+                return true;
+            }))
+            ->willReturn(
+                (string) json_encode(self::lovedTracksResponse())
+            );
+
+        $client = new LastfmClient('test-api-key', httpClient: $httpClient);
+        $client->user()->getLovedTracks('testuser', 10, 3);
+    }
+
+    #[Test]
+    public function itUsesDefaultLimitAndPageForLovedTracks(): void
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('get')
+            ->with($this->callback(function (string $url): bool {
+                $query = parse_url($url, PHP_URL_QUERY);
+                $this->assertIsString($query);
+                parse_str((string) $query, $params);
+                $this->assertSame('50', $params['limit']);
+                $this->assertSame('1', $params['page']);
+
+                return true;
+            }))
+            ->willReturn(
+                (string) json_encode(self::lovedTracksResponse())
+            );
+
+        $client = new LastfmClient('test-api-key', httpClient: $httpClient);
+        $client->user()->getLovedTracks('rj');
+    }
+
+    #[Test]
+    public function itParsesLovedTrackImages(): void
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $httpClient->method('get')
+            ->willReturn(
+                (string) json_encode(self::lovedTracksResponse())
+            );
+
+        $client = new LastfmClient('test-api-key', httpClient: $httpClient);
+        $result = $client->user()->getLovedTracks('rj');
+
+        $this->assertCount(2, $result->items[0]->images);
+        $this->assertInstanceOf(
+            ImageDto::class,
+            $result->items[0]->images[0],
+        );
+        $this->assertSame('small', $result->items[0]->images[0]->size);
+    }
+
     /**
      * @return array{user: array<string, mixed>}
      */
@@ -72,6 +180,73 @@ final class UserServiceTest extends TestCase
                 ],
                 'registered' => ['unixtime' => '1037793040', '#text' => 1037793040],
                 'type' => 'alum',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function lovedTracksResponse(): array
+    {
+        return [
+            'lovedtracks' => [
+                'track' => [
+                    self::lovedTrackItem('Davy Crochet', 'The Backseat Lovers'),
+                    self::lovedTrackItem('Lucky', 'Radiohead'),
+                ],
+                '@attr' => [
+                    'page' => '1',
+                    'total' => '7790',
+                    'user' => 'rj',
+                    'perPage' => '2',
+                    'totalPages' => '3895',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function lovedTrackItem(
+        string $track,
+        string $artist,
+    ): array {
+        return [
+            'name' => $track,
+            'url' => "https://www.last.fm/music/{$artist}/_/{$track}",
+            'mbid' => 'track-mbid-123',
+            'artist' => [
+                'name' => $artist,
+                'url' => "https://www.last.fm/music/{$artist}",
+                'mbid' => 'artist-mbid-123',
+            ],
+            'date' => [
+                'uts' => '1603112664',
+                '#text' => '19 Oct 2020, 13:04',
+            ],
+            'image' => self::imageData(),
+            'streamable' => [
+                'fulltrack' => '0',
+                '#text' => '0',
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array{size: string, '#text': string}>
+     */
+    private static function imageData(): array
+    {
+        return [
+            [
+                'size' => 'small',
+                '#text' => 'https://lastfm.freetls.fastly.net/i/u/34s/img.png',
+            ],
+            [
+                'size' => 'large',
+                '#text' => 'https://lastfm.freetls.fastly.net/i/u/174s/img.png',
             ],
         ];
     }


### PR DESCRIPTION
Closes #20

## Changes

Implements the `user.getLovedTracks` endpoint, returning a paginated list of tracks a user has loved.

### New files

- `src/Dto/User/LovedTrackDto.php` — DTO with flattened artist, date, and streamable fields via `#[MapFrom]`
- `tests/Dto/User/LovedTrackDtoTest.php` — unit tests for all DTO fields
- `docs/user/getLovedTracks.md` — full endpoint documentation with examples

### Updated

- `src/Service/UserService.php` — added `getLovedTracks(string $user, int $limit, int $page)` method
- `tests/Service/UserServiceTest.php` — added tests for response mapping, pagination, parameters, defaults, and images
- `README.md` — added endpoint to the table

### Reuses

- `PaginatedResponse<LovedTrackDto>` and `PaginationDto` for pagination
- `ImageDto` for track images
- `DtoMapper` with `#[MapFrom]`, `#[CastTo]`, `#[ArrayOf]` attributes

### Quality

- GrumPHP (phpcs, phpstan level 9, phpunit): all green
- Infection: **100% MSI** (115/115 mutants killed)
