### PR TITLE
refactor: extract paginated endpoint helper into AbstractService

### DIFF
--- a/src/Service/AbstractService.php
+++ b/src/Service/AbstractService.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rjds\PhpLastfmClient\Service;
+
+use Rjds\PhpDto\DtoMapper;
+use Rjds\PhpLastfmClient\Dto\Common\PaginatedResponse;
+use Rjds\PhpLastfmClient\Dto\Common\PaginationDto;
+use Rjds\PhpLastfmClient\LastfmClient;
+
+abstract readonly class AbstractService
+{
+    public function __construct(
+        protected LastfmClient $client,
+        protected DtoMapper $mapper = new DtoMapper(),
+    ) {
+    }
+
+    /**
+     * Fetch a paginated API endpoint and map the results to DTOs.
+     *
+     * @template T of object
+     *
+     * @param string $method The API method (e.g. 'user.getlovedtracks')
+     * @param array<string, string|int> $params Query parameters including limit/page
+     * @param string $wrapperKey Top-level response key (e.g. 'lovedtracks')
+     * @param string $itemsKey Key within the wrapper containing the items (e.g. 'track')
+     * @param class-string<T> $dtoClass The DTO class to map each item to
+     *
+     * @return PaginatedResponse<T>
+     */
+    protected function paginate(
+        string $method,
+        array $params,
+        string $wrapperKey,
+        string $itemsKey,
+        string $dtoClass,
+    ): PaginatedResponse {
+        $response = $this->client->call($method, $params);
+
+        /** @var array<string, mixed> $data */
+        $data = $response[$wrapperKey];
+
+        /** @var list<array<string, mixed>> $itemList */
+        $itemList = $data[$itemsKey];
+
+        /** @var list<T> $items */
+        $items = [];
+        foreach ($itemList as $item) {
+            $items[] = $this->mapper->map($item, $dtoClass);
+        }
+
+        /** @var array<string, mixed> $attrData */
+        $attrData = $data['@attr'];
+        $pagination = $this->mapper->map($attrData, PaginationDto::class);
+
+        return new PaginatedResponse($items, $pagination);
+    }
+}

--- a/src/Service/AuthService.php
+++ b/src/Service/AuthService.php
@@ -4,19 +4,11 @@ declare(strict_types=1);
 
 namespace Rjds\PhpLastfmClient\Service;
 
-use Rjds\PhpDto\DtoMapper;
 use Rjds\PhpLastfmClient\Dto\Auth\SessionDto;
-use Rjds\PhpLastfmClient\LastfmClient;
 
-final readonly class AuthService
+final readonly class AuthService extends AbstractService
 {
     private const string AUTH_URL = 'https://www.last.fm/api/auth/';
-
-    public function __construct(
-        private LastfmClient $client,
-        private DtoMapper $mapper = new DtoMapper(),
-    ) {
-    }
 
     /**
      * Get an unauthorized request token.

--- a/src/Service/LibraryService.php
+++ b/src/Service/LibraryService.php
@@ -4,20 +4,11 @@ declare(strict_types=1);
 
 namespace Rjds\PhpLastfmClient\Service;
 
-use Rjds\PhpDto\DtoMapper;
 use Rjds\PhpLastfmClient\Dto\Common\PaginatedResponse;
-use Rjds\PhpLastfmClient\Dto\Common\PaginationDto;
 use Rjds\PhpLastfmClient\Dto\Library\LibraryArtistDto;
-use Rjds\PhpLastfmClient\LastfmClient;
 
-final readonly class LibraryService
+final readonly class LibraryService extends AbstractService
 {
-    public function __construct(
-        private LastfmClient $client,
-        private DtoMapper $mapper = new DtoMapper(),
-    ) {
-    }
-
     /**
      * Get a paginated list of all the artists in a user's library.
      *
@@ -27,28 +18,10 @@ final readonly class LibraryService
      */
     public function getArtists(string $user, int $limit = 50, int $page = 1): PaginatedResponse
     {
-        $response = $this->client->call('library.getartists', [
+        return $this->paginate('library.getartists', [
             'user' => $user,
             'limit' => $limit,
             'page' => $page,
-        ]);
-
-        /** @var array<string, mixed> $data */
-        $data = $response['artists'];
-
-        /** @var list<array<string, mixed>> $artistList */
-        $artistList = $data['artist'];
-
-        /** @var list<LibraryArtistDto> $artists */
-        $artists = [];
-        foreach ($artistList as $item) {
-            $artists[] = $this->mapper->map($item, LibraryArtistDto::class);
-        }
-
-        /** @var array<string, mixed> $attrData */
-        $attrData = $data['@attr'];
-        $pagination = $this->mapper->map($attrData, PaginationDto::class);
-
-        return new PaginatedResponse($artists, $pagination);
+        ], 'artists', 'artist', LibraryArtistDto::class);
     }
 }

--- a/src/Service/TrackService.php
+++ b/src/Service/TrackService.php
@@ -4,20 +4,12 @@ declare(strict_types=1);
 
 namespace Rjds\PhpLastfmClient\Service;
 
-use Rjds\PhpDto\DtoMapper;
 use Rjds\PhpLastfmClient\Dto\Track\Scrobble;
 use Rjds\PhpLastfmClient\Dto\Track\ScrobbleResponseDto;
 use Rjds\PhpLastfmClient\Dto\Track\ScrobbleResultDto;
-use Rjds\PhpLastfmClient\LastfmClient;
 
-final readonly class TrackService
+final readonly class TrackService extends AbstractService
 {
-    public function __construct(
-        private LastfmClient $client,
-        private DtoMapper $mapper = new DtoMapper(),
-    ) {
-    }
-
     /**
      * Scrobble a single track.
      *

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -4,21 +4,12 @@ declare(strict_types=1);
 
 namespace Rjds\PhpLastfmClient\Service;
 
-use Rjds\PhpDto\DtoMapper;
 use Rjds\PhpLastfmClient\Dto\Common\PaginatedResponse;
-use Rjds\PhpLastfmClient\Dto\Common\PaginationDto;
 use Rjds\PhpLastfmClient\Dto\User\LovedTrackDto;
 use Rjds\PhpLastfmClient\Dto\User\UserDto;
-use Rjds\PhpLastfmClient\LastfmClient;
 
-final readonly class UserService
+final readonly class UserService extends AbstractService
 {
-    public function __construct(
-        private LastfmClient $client,
-        private DtoMapper $mapper = new DtoMapper(),
-    ) {
-    }
-
     /**
      * Get information about a user profile.
      *
@@ -43,28 +34,10 @@ final readonly class UserService
      */
     public function getLovedTracks(string $user, int $limit = 50, int $page = 1): PaginatedResponse
     {
-        $response = $this->client->call('user.getlovedtracks', [
+        return $this->paginate('user.getlovedtracks', [
             'user' => $user,
             'limit' => $limit,
             'page' => $page,
-        ]);
-
-        /** @var array<string, mixed> $data */
-        $data = $response['lovedtracks'];
-
-        /** @var list<array<string, mixed>> $trackList */
-        $trackList = $data['track'];
-
-        /** @var list<LovedTrackDto> $tracks */
-        $tracks = [];
-        foreach ($trackList as $item) {
-            $tracks[] = $this->mapper->map($item, LovedTrackDto::class);
-        }
-
-        /** @var array<string, mixed> $attrData */
-        $attrData = $data['@attr'];
-        $pagination = $this->mapper->map($attrData, PaginationDto::class);
-
-        return new PaginatedResponse($tracks, $pagination);
+        ], 'lovedtracks', 'track', LovedTrackDto::class);
     }
 }


### PR DESCRIPTION
Closes #22

## Summary

Extracts the repeated paginated endpoint boilerplate into a shared `AbstractService` base class, significantly reducing code duplication across all services.

## Changes

### New: `AbstractService` base class
- Shared constructor (`$client`, `$mapper`) inherited by all services
- `paginate()` helper method that handles the full pagination flow:
  - Calls the API
  - Extracts the wrapper and items keys
  - Maps each item to the given DTO class
  - Extracts `@attr` pagination metadata
  - Returns a `PaginatedResponse<T>`

### Refactored services
All 4 services now extend `AbstractService`:
- **`UserService`**: `getLovedTracks()` reduced from 15 lines to 5
- **`LibraryService`**: `getArtists()` reduced from 15 lines to 5
- **`TrackService`**: inherits constructor (no pagination methods yet)
- **`AuthService`**: inherits constructor (no pagination methods yet)

### Before vs After

**Before** (repeated in every paginated method):
```php
$response = $this->client->call('user.getlovedtracks', $params);
$data = $response['lovedtracks'];
$trackList = $data['track'];
$tracks = [];
foreach ($trackList as $item) {
    $tracks[] = $this->mapper->map($item, LovedTrackDto::class);
}
$attrData = $data['@attr'];
$pagination = $this->mapper->map($attrData, PaginationDto::class);
return new PaginatedResponse($tracks, $pagination);
```

**After**:
```php
return $this->paginate('user.getlovedtracks', $params, 'lovedtracks', 'track', LovedTrackDto::class);
```

## Quality

- All existing tests pass unchanged
- GrumPHP (phpcs + phpstan + phpunit): **all green**
- Infection: **100% MSI** (115/115 mutants killed)
